### PR TITLE
6914 - Add global support for the cht script api

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The list of available actions can be seen via `medic-conf --help`.
 
 _Added in v3.2.0_
 
-In order to avoid overwriting someone elses configuration medic-conf records the last uploaded configuration snapshot in the `.snapshots` directory. The `remote.json` file should be committed to your repository along with the associated configuration change. When uploading future configuration if medic-conf detects the snapshot doesn't match the configuration on the server you will be prompted to overwrite or cancel.
+In order to avoid overwriting someone else configuration medic-conf records the last uploaded configuration snapshot in the `.snapshots` directory. The `remote.json` file should be committed to your repository along with the associated configuration change. When uploading future configuration if medic-conf detects the snapshot doesn't match the configuration on the server you will be prompted to overwrite or cancel.
 
 # Currently supported
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ The list of available actions can be seen via `medic-conf --help`.
 
 _Added in v3.2.0_
 
-In order to avoid overwriting someone else configuration medic-conf records the last uploaded configuration snapshot in the `.snapshots` directory. The `remote.json` file should be committed to your repository along with the associated configuration change. When uploading future configuration if medic-conf detects the snapshot doesn't match the configuration on the server you will be prompted to overwrite or cancel.
+In order to avoid overwriting someone else's configuration medic-conf records the last uploaded configuration snapshot in the `.snapshots` directory. The `remote.json` file should be committed to your repository along with the associated configuration change. When uploading future configuration if medic-conf detects the snapshot doesn't match the configuration on the server you will be prompted to overwrite or cancel.
 
 # Currently supported
 

--- a/src/contact-summary/.eslintrc
+++ b/src/contact-summary/.eslintrc
@@ -33,6 +33,7 @@
     "reports": true,
     "lineage": true,
     "uhcStats": true,
-    "targetDoc": true
+    "targetDoc": true,
+    "cht": true
   }
 }

--- a/src/nools/.eslintrc
+++ b/src/nools/.eslintrc
@@ -30,6 +30,7 @@
   },
   "globals": {
     "user": true,
-    "Utils": true
+    "Utils": true,
+    "cht": true
   }
 }


### PR DESCRIPTION
# Description

This PR adds the `cht` global to the eslint files.

https://github.com/medic/cht-core/issues/6914

CHT-Core: https://github.com/medic/cht-core/pull/7126
CHT-Docs: https://github.com/medic/cht-docs/pull/518 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
