### PR TITLE
add check to ensure server is reachable

### DIFF
--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -10,6 +10,7 @@ const redactBasicAuth = require('redact-basic-auth');
 const shellCompletionSetup = require('../cli/shell-completion-setup');
 const supportedActions = require('../cli/supported-actions');
 const usage = require('../cli/usage');
+const request = require('request-promise-native');
 
 const { error, info, warn } = log;
 const defaultActions = [
@@ -163,6 +164,12 @@ module.exports = async (argv, env) => {
     apiUrl = getApiUrl(cmdArgs, env);
     if (!apiUrl) {
       error('Failed to obtain a url to the API');
+      return -1;
+    }
+    try {
+      await request.get(apiUrl);
+    } catch (err) {
+      error(`Failed to get a response from ${apiUrl}. Maybe you entered the wrong URL, wrong port or the instance is not started? Please check and try again.`);
       return -1;
     }
   }

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -167,6 +167,7 @@ module.exports = async (argv, env) => {
       return -1;
     }
     try {
+      info(`Checking that ${apiUrl} is available...`);
       await request.get(apiUrl);
     } catch (err) {
       error(`Failed to get a response from ${apiUrl}. Maybe you entered the wrong URL, wrong port or the instance is not started? Please check and try again.`);

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -32,6 +32,9 @@ describe('main', () => {
           resolve: () => 'resolved',
         },
       },
+      request: {
+        get: sinon.stub()
+      }
     };
 
     for (let attr of Object.keys(mocks)) {
@@ -186,5 +189,19 @@ describe('main', () => {
     const actual = await main([...normalArgv, '---url=https://admin:pwd@url.app.medicmobile.org/', '--force']);
     expect(userPrompt.keyInYN.callCount).to.eq(1);
     expect(actual).to.be.undefined;
+  });
+
+  it('should provide an error if action requires an instance and apiUrl does not respond', async() => {
+    mocks.request.get.rejects();
+    await main([...normalArgv, 'upload-app-forms']);
+    expect(mocks.error.callCount).to.eq(1);
+    expect(mocks.error.args[0][0]).to
+      .eq('Failed to get a response from http://api. Maybe you entered the wrong URL, wrong port or the instance is not started? Please check and try again');
+  });
+
+  it('should continue without error if action requires an instance and apiUrl responds', async() => {
+    mocks.request.get.resolves();
+    await main([...normalArgv, 'upload-app-forms']);
+    expect(mocks.error.callCount).to.eq(0);
   });
 });

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -196,7 +196,7 @@ describe('main', () => {
     await main([...normalArgv, 'upload-app-forms']);
     expect(mocks.error.callCount).to.eq(1);
     expect(mocks.error.args[0][0]).to
-      .eq('Failed to get a response from http://api. Maybe you entered the wrong URL, wrong port or the instance is not started? Please check and try again');
+      .eq('Failed to get a response from http://api. Maybe you entered the wrong URL, wrong port or the instance is not started? Please check and try again.');
   });
 
   it('should continue without error if action requires an instance and apiUrl responds', async() => {


### PR DESCRIPTION
# Description

Add a check to make sure the instance is reachable for actions that require an instance

medic/cht-conf#380

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
