### PR TITLE
add 3.8.0 release notes and bump up version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-conf",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-conf",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Configure CHT deployments",
   "main": "./src/lib/main.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cht-conf",
-  "version": "3.8.0",
+  "version": "3.7.0",
   "description": "Configure CHT deployments",
   "main": "./src/lib/main.js",
   "engines": {

--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,25 @@
 # Release Notes
 
+## 3.8.0
+
+### Ability to edit a contact type
+
+It is now possible to edit a contact type. There is a new flag `--updateOfflineDocs` that can be passed to the `edit-contacts` action which updates docs in the directory provided in `--docDirectoryPath` instead of downloading the docs from the database.
+
+[#408](https://github.com/medic/cht-conf/issues/408)
+
+### Fail early if .eslintrc file is not provided
+
+Running the `compile-app-settings` command now fails early and provides a more descriptive error message to users.
+
+[#333](https://github.com/medic/cht-conf/issues/333)
+
+### Check to make sure CHT instance is up
+
+Commands that require an instance now fail with a more descriptive error message if the instance provided is not reachable
+
+[#380](https://github.com/medic/cht-conf/issues/380)
+
 ## 3.7.0
 
 ### The repository has been renamed to `cht-conf`. 

--- a/release-notes.md
+++ b/release-notes.md
@@ -4,7 +4,7 @@
 
 ### Ability to edit a contact type
 
-It is now possible to edit a contact type. There is a new flag `--updateOfflineDocs` that can be passed to the `edit-contacts` action which updates docs in the directory provided in `--docDirectoryPath` instead of downloading the docs from the database.
+It is now possible to edit a contact type with the `edit-contacts` action. Additionally, `edit-contacts` accepts a new flag `--updateOfflineDocs`, that allows editing json docs that already exist in the directory provided in `--docDirectoryPath` instead of downloading the docs from the database.
 
 [#408](https://github.com/medic/cht-conf/issues/408)
 


### PR DESCRIPTION
# Description

3.8.0 release notes

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
