### PR TITLE
refactor the moving of reports to use a recursive function to improve…

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ To develop a new action or improve an existing one, check the ["Actions" doc](sr
 
 ## Testing
 
-Execute `npm test` to run static analysis checks and the test suite.
+Execute `npm test` to run static analysis checks and the test suite. Requires Docker to run integration tests against a CouchDB instance. 
 
 ## Executing your local branch
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "eslint": "eslint src/**/*.js test/*.js test/**/*.js",
     "docker-start-couchdb": "npm run docker-stop-couchdb && docker run -d -p 6984:5984 --rm --name cht-conf-couchdb couchdb:2.3.1 && sh test/scripts/wait_for_response_code.sh 6984 200 CouchDB",
     "docker-stop-couchdb": "docker stop cht-conf-couchdb || true",
-    "test": "npm run eslint && npm run docker-start-couchdb && npm run clean && mkdir -p build/test && cp -r test/data build/test/data && cd build/test && nyc --reporter=html mocha --forbid-only ../../test/**/*.spec.js && cd ../.. && npm run docker-stop-couchdb"
+    "test": "npm run eslint && npm run docker-start-couchdb && npm run clean && mkdir -p build/test && cp -r test/data build/test/data && cd build/test && nyc --reporter=html mocha --forbid-only ../../test/**/*.spec.js && cd ../.. && npm run docker-stop-couchdb",
     "semantic-release": "semantic-release"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "clean": "rm -rf ./build/",
     "eslint": "eslint src/**/*.js test/*.js test/**/*.js",
-    "test": "npm run eslint && npm run clean && mkdir -p build/test && cp -r test/data build/test/data && cd build/test && nyc --reporter=html mocha --forbid-only ../../test/**/*.spec.js && cd ../.."
+    "docker-start-couchdb": "npm run docker-stop-couchdb && docker run -d -p 6984:5984 --rm --name cht-conf-couchdb couchdb:2.3.1 && sh test/scripts/wait_for_response_code.sh 6984 200 CouchDB",
+    "docker-stop-couchdb": "docker stop cht-conf-couchdb || true",
+    "test": "npm run eslint && npm run docker-start-couchdb && npm run clean && mkdir -p build/test && cp -r test/data build/test/data && cd build/test && nyc --reporter=html mocha --forbid-only ../../test/**/*.spec.js && cd ../.. && npm run docker-stop-couchdb"
   },
   "bin": {
     "medic-conf": "src/bin/index.js",

--- a/test/fn/move-contacts.spec.js
+++ b/test/fn/move-contacts.spec.js
@@ -579,6 +579,7 @@ describe('move-contacts', () => {
 
   describe('batching works as expected', () => {
     beforeEach(async () => {
+      moveContactsModule.__set__('BATCH_SIZE', 1);
       await mockReport(pouchDb, {
         id: 'report_2',
         creatorId: 'health_center_1_contact',
@@ -588,8 +589,12 @@ describe('move-contacts', () => {
         id: 'report_3',
         creatorId: 'health_center_1_contact',
       });
+
+      await mockReport(pouchDb, {
+        id: 'report_4',
+        creatorId: 'health_center_1_contact',
+      });
     });
-    moveContactsModule.__set__('BATCH_SIZE', 1);
     it('move health_center_1 to district_2 in small batches', async () => {
       await updateLineagesAndStage({
         contactIds: ['health_center_1'],

--- a/test/scripts/wait_for_response_code.sh
+++ b/test/scripts/wait_for_response_code.sh
@@ -1,0 +1,8 @@
+count=0
+echo 'Starting curl check'
+while [ `curl -o /dev/null -s -w "%{http_code}\n" http://localhost:$1` -ne "$2" -a $count -lt 300 ]
+  do count=$((count+=1))
+  echo "waiting for $3 to respond with 200 status code. Current count is $count" 
+  sleep 1 
+done
+echo 'Ended curl check'


### PR DESCRIPTION
# Description

Improve performance of move contacts action which currently fails due to loading all reports to be moved into memory. I make use of a recursive function to query the reports to make use of limit and skip.

This can be tested with this command `cht --instance=clone-upgrade-muso-mali.dev  move-contacts -- --contacts=498e52d5b282433f88018c7ef4da67ee --parent=dc5112a5-52dc-4f55-954e-80928a7c2567`

medic/cht-conf#432

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
