### PR TITLE
Fix archive mode not working with no instance

### DIFF
--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -87,6 +87,15 @@ const api = {
     });
   },
 
+  /**
+   * "Ping" request to the API to see if it's alive. The request
+   * is made to a "lightweight" endpoint that only returns a HTTP 302,
+   * and an empty promise is returned instead.
+   */
+  ping: async () => {
+    await request.get(`${environment.apiUrl}/medic`);
+  },
+
   version() {
     return request({ uri: `${environment.instanceUrl}/api/deploy-info`, method: 'GET', json: true }) // endpoint added in 3.5
       .then(deploy_info => deploy_info && deploy_info.version);

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -88,12 +88,21 @@ const api = {
   },
 
   /**
-   * "Ping" request to the API to see if it's alive. The request
+   * Check whether the API it's alive or not. The request
    * is made to a "lightweight" endpoint that only returns a HTTP 302,
-   * and an empty promise is returned instead.
+   * and an promise is returned with true (available) or false.
    */
-  ping: async () => {
-    await request.get(`${environment.apiUrl}/medic`);
+  available: async () => {
+    const url = `${environment.apiUrl}/`;
+    try {
+      log.info(`Checking that ${url} is available...`);
+      await request.get(url);
+      return true;
+    } catch (err) {
+      log.error(`Failed to get a response from ${url}. Maybe you entered the wrong URL, `
+                + 'wrong port or the instance is not started? Please check and try again.');
+      return false;
+    }
   },
 
   version() {

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -88,7 +88,7 @@ const api = {
   },
 
   /**
-   * Check whether the API it's alive or not. The request
+   * Check whether the API is alive or not. The request
    * is made to a "lightweight" endpoint that only returns a HTTP 302,
    * and an promise is returned with true (available) or false.
    */

--- a/src/lib/archiving-api.js
+++ b/src/lib/archiving-api.js
@@ -21,6 +21,8 @@ const archivingApi = {
     return Promise.resolve('{ "success": true }');
   },
 
+  ping: async () => { },
+
   version() {
     return '1000.0.0'; // assume the latest version when archiving
   },

--- a/src/lib/archiving-api.js
+++ b/src/lib/archiving-api.js
@@ -21,7 +21,7 @@ const archivingApi = {
     return Promise.resolve('{ "success": true }');
   },
 
-  ping: async () => { },
+  available: async () => true,
 
   version() {
     return '1000.0.0'; // assume the latest version when archiving

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -10,7 +10,7 @@ const redactBasicAuth = require('redact-basic-auth');
 const shellCompletionSetup = require('../cli/shell-completion-setup');
 const supportedActions = require('../cli/supported-actions');
 const usage = require('../cli/usage');
-const request = require('request-promise-native');
+const api = require('../lib/api');
 
 const { error, info, warn } = log;
 const defaultActions = [
@@ -166,13 +166,6 @@ module.exports = async (argv, env) => {
       error('Failed to obtain a url to the API');
       return -1;
     }
-    try {
-      info(`Checking that ${apiUrl} is available...`);
-      await request.get(apiUrl);
-    } catch (err) {
-      error(`Failed to get a response from ${apiUrl}. Maybe you entered the wrong URL, wrong port or the instance is not started? Please check and try again.`);
-      return -1;
-    }
   }
 
   let extraArgs = cmdArgs['--'];
@@ -189,6 +182,16 @@ module.exports = async (argv, env) => {
     cmdArgs.force,
     cmdArgs['skip-translation-check']
   );
+
+  if (apiUrl) {
+    try {
+      info(`Checking that ${apiUrl} is available...`);
+      await api().ping();
+    } catch (err) {
+      error(`Failed to get a response from ${apiUrl}. Maybe you entered the wrong URL, wrong port or the instance is not started? Please check and try again.`);
+      return -1;
+    }
+  }
 
   const productionUrlMatch = environment.instanceUrl && environment.instanceUrl.match(/^https:\/\/(?:[^@]*@)?(.*)\.(app|dev)\.medicmobile\.org(?:$|\/)/);
   const expectedOptions = ['alpha', projectName];

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -183,14 +183,8 @@ module.exports = async (argv, env) => {
     cmdArgs['skip-translation-check']
   );
 
-  if (apiUrl) {
-    try {
-      info(`Checking that ${apiUrl} is available...`);
-      await api().ping();
-    } catch (err) {
-      error(`Failed to get a response from ${apiUrl}. Maybe you entered the wrong URL, wrong port or the instance is not started? Please check and try again.`);
-      return -1;
-    }
+  if (apiUrl && !await api().available()) {
+    return false;
   }
 
   const productionUrlMatch = environment.instanceUrl && environment.instanceUrl.match(/^https:\/\/(?:[^@]*@)?(.*)\.(app|dev)\.medicmobile\.org(?:$|\/)/);

--- a/test/lib/api.spec.js
+++ b/test/lib/api.spec.js
@@ -213,7 +213,7 @@ describe('api', () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
       sinon.stub(mockRequest, 'get').rejects('Ups');
       sinon.stub(log, 'error');
-      let isAvailable = await api().available();
+      const isAvailable = await api().available();
       expect(isAvailable).to.be.false;
       expect(log.error.callCount).to.eq(1);
       expect(log.error.args[0][0]).to.eq(

--- a/test/lib/api.spec.js
+++ b/test/lib/api.spec.js
@@ -220,5 +220,15 @@ describe('api', () => {
         'Failed to get a response from http://api/medic/. Maybe you entered the wrong URL, ' +
         'wrong port or the instance is not started? Please check and try again.');
     });
+
+    it('should return true if archive mode is enable even when api is not available', async () => {
+      sinon.stub(environment, 'isArchiveMode').get(() => true);
+      sinon.stub(mockRequest, 'get').rejects('Ups');
+      sinon.stub(log, 'error');
+      const isAvailable = await api().available();
+      expect(isAvailable).to.be.true;
+      expect(log.error.callCount).to.eq(0);
+      expect(mockRequest.callCount).to.eq(0);   // api is not called
+    });
   });
 });

--- a/test/lib/api.spec.js
+++ b/test/lib/api.spec.js
@@ -195,4 +195,30 @@ describe('api', () => {
       assert.equal(cacheGetSpy.callCount, 0);      // cache not used
     });
   });
+
+  describe('available', async () => {
+
+    beforeEach(() => sinon.stub(environment, 'apiUrl').get(() => 'http://api/medic'));
+
+    it('should return true in no error found in request', async () => {
+      sinon.stub(environment, 'isArchiveMode').get(() => false);
+      sinon.stub(mockRequest, 'get').resolves('okey dokey');
+      sinon.stub(log, 'error');
+      let isAvailable = await api().available();
+      expect(isAvailable).to.be.true;
+      expect(log.error.callCount).to.eq(0);
+    });
+
+    it('should return false and provide an error if request fails', async () => {
+      sinon.stub(environment, 'isArchiveMode').get(() => false);
+      sinon.stub(mockRequest, 'get').rejects('Ups');
+      sinon.stub(log, 'error');
+      let isAvailable = await api().available();
+      expect(isAvailable).to.be.false;
+      expect(log.error.callCount).to.eq(1);
+      expect(log.error.args[0][0]).to.eq(
+        'Failed to get a response from http://api/medic/. Maybe you entered the wrong URL, ' +
+        'wrong port or the instance is not started? Please check and try again.');
+    });
+  });
 });

--- a/test/lib/api.spec.js
+++ b/test/lib/api.spec.js
@@ -200,7 +200,7 @@ describe('api', () => {
 
     beforeEach(() => sinon.stub(environment, 'apiUrl').get(() => 'http://api/medic'));
 
-    it('should return true in no error found in request', async () => {
+    it('should return true if no error found in request', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
       sinon.stub(mockRequest, 'get').resolves('okey dokey');
       sinon.stub(log, 'error');
@@ -221,7 +221,7 @@ describe('api', () => {
         'wrong port or the instance is not started? Please check and try again.');
     });
 
-    it('should return true if archive mode is enable even when api is not available', async () => {
+    it('should return true if archive mode is enabled even when api is not available', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => true);
       sinon.stub(mockRequest, 'get').rejects('Ups');
       sinon.stub(log, 'error');

--- a/test/lib/api.spec.js
+++ b/test/lib/api.spec.js
@@ -204,7 +204,7 @@ describe('api', () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
       sinon.stub(mockRequest, 'get').resolves('okey dokey');
       sinon.stub(log, 'error');
-      let isAvailable = await api().available();
+      const isAvailable = await api().available();
       expect(isAvailable).to.be.true;
       expect(log.error.callCount).to.eq(0);
     });

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -194,7 +194,7 @@ describe('main', () => {
   });
 
   it('should return earlier with false value if api is not available', async () => {
-    apiAvailable = sinon.stub().resolves(false);
+    apiAvailable.resolves(false);
     const earlyResult = await main([...normalArgv, 'upload-app-forms']);
     expect(earlyResult).to.be.false;
     expect(apiAvailable.callCount).to.eq(1);

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -201,7 +201,7 @@ describe('main', () => {
   });
 
   it('should continue without error if action requires an instance and apiUrl responds', async () => {
-    apiAvailable = sinon.stub().resolves(true);
+    apiAvailable.resolves(true);
     const result = await main([...normalArgv, 'upload-app-forms']);
     expect(result).to.be.undefined;
     expect(apiAvailable.callCount).to.eq(1);


### PR DESCRIPTION
Move "ping" check to the `api` module, and implement the same in the `archiving-api` module for `--archive` mode.

medic/cht-conf#434

# Description

In the archive module is not expected the API to be running.

The call to `api().ping()` was moved after the `environment.initialize(..)` call, because the api module requires that initialization to happens first.

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
