### PR TITLE
fix(#455): allow empty translation constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "cht-conf-publish-test",
+  "name": "cht-conf",
   "version": "3.9.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -1037,9 +1037,9 @@
       "dev": true
     },
     "@medic/translation-checker": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@medic/translation-checker/-/translation-checker-1.0.0.tgz",
-      "integrity": "sha512-N51WNk6StZnLZk68AZ0+zrd8RwFarV6CqP4c5+Q0ddAM7MhKolDobiCqMfqzmDHgvbZdoVYurPh/s/h8HpPlVA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@medic/translation-checker/-/translation-checker-1.0.1.tgz",
+      "integrity": "sha512-yMCqW6EgDvGMBCnwaFWe+J1GgAddK9U2xsoXyCsrRS47JoRTxGTfL8LIybgTX1/vUEVRH0ZS0dt1+AAUUZ3MGQ==",
       "requires": {
         "iso-639-1": "^2.1.4",
         "messageformat": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "https://github.com/medic/cht-conf#readme",
   "dependencies": {
     "@hapi/joi": "^16.1.8",
-    "@medic/translation-checker": "1.0.0",
+    "@medic/translation-checker": "^1.0.1",
     "canonical-json": "0.0.4",
     "csv-parse": "^4.16.0",
     "dom-compare": "^0.6.0",


### PR DESCRIPTION
Review please @mrsarm ... just bumping the translation lib version.

#455 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
