### PR TITLE
Clarify database name usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ If a different username is required, add the `--user` switch:
 
 	cht --url=https://username:password@example.com:12345
 
+**NB** - When specifying the URL with `--url`, be sure not to specify the CouchDB database name in the URL. The CHT API will find the correct database.
+
 ### Into an archive to be uploaded later
 
     cht --archive


### PR DESCRIPTION
# Description

Minor tweak to `cht-conf` readme to avoid errors when specifying alternate databases in `--url`

medic/cht-conf#464

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
