### PR TITLE
Allow more characters in form and field names

### DIFF
--- a/src/lib/validate-app-settings.js
+++ b/src/lib/validate-app-settings.js
@@ -1,7 +1,7 @@
 const joi = require('@hapi/joi');
 
 const FormsSchema = joi.object().pattern(
-  /\w{1,30}/,
+  joi.string().min(1),
   joi.object({
     meta: joi.object({
       code: joi.string().required(),
@@ -10,7 +10,7 @@ const FormsSchema = joi.object().pattern(
       subject_key: joi.string()
     }).required(),
     fields: joi.object().pattern(
-      /\w{1,30}/,
+      joi.string().min(1),
       joi.object({
         type: joi.string().required(),
         labels: joi.object({

--- a/test/lib/validate-app-settings.spec.js
+++ b/test/lib/validate-app-settings.spec.js
@@ -1,0 +1,87 @@
+const { expect } = require('chai');
+
+const validateAppSettings = require('../../src/lib/validate-app-settings');
+
+describe('validate-app-settings', () => {
+
+  describe('validateFormsSchema', () => {
+
+    const isValid = (formsObject) => {
+      const result = validateAppSettings.validateFormsSchema(formsObject);
+      expect(result.valid).to.be.true;
+    };
+
+    const isNotValid = (formsObject, errorMessage) => {
+      const result = validateAppSettings.validateFormsSchema(formsObject);
+      expect(result.valid).to.be.false;
+      expect(result.error.details.length).to.equal(1);
+      expect(result.error.details[0].message).to.equal(errorMessage);
+    };
+
+    it('returns true for empty config', () => {
+      isValid({});
+    });
+
+    it('returns true for basic config', () => {
+      isValid({
+        DR: {
+          meta: { code: 'DR' },
+          fields: {
+            patient_id: {
+              position: 0,
+              flags: { input_digits_only: true },
+              length: [ 5, 13 ],
+              type: 'string',
+              required: true
+            }
+          }
+        }
+      });
+    });
+
+    it('returns true when form name contains Nepali characters - #471', () => {
+      isValid({
+        क: {
+          meta: { code: 'क' },
+          fields: {
+            क: { type: 'string' }
+          }
+        }
+      });
+    });
+
+    it('returns true when form name contains French accents', () => {
+      isValid({
+        voilà: {
+          meta: { code: 'voilà' },
+          fields: {
+            voilà: { type: 'string' }
+          }
+        }
+      });
+    });
+
+    it('returns true when field name contains anything', () => {
+      isValid({
+        r: {
+          meta: { code: 'r' },
+          fields: {
+            '#!$àक': { type: 'string' }
+          }
+        }
+      });
+    });
+
+    it('returns false when meta missing', () => {
+      isNotValid({
+        DR: {
+          fields: {
+            patient_id: { type: 'string' }
+          }
+        }
+      }, '"DR.meta" is required');
+    });
+
+  });
+
+});


### PR DESCRIPTION
# Description

The initial request was to make the regex more inclusive to support all unicode characters, but in investigating the parsing code I realised we allow multiple different formats for SMS messages, some of which allow for a wide range of possible characters in form and field names. This change removes all schema limitations from the form and field names other than forcing them to be strings of length at least 1.

medic/cht-conf#471

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
