### PR TITLE
Updated references from master branch to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   release:
     name: Release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -18,5 +18,5 @@
       }
     ]
   ],
-  "branches": ["master"]
+  "branches": ["main"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,7 +192,7 @@ As of this release no docs on the server will be touched unless some configurati
 
 ### New action to bulk-edit contacts
 
-You can now bulk edit contacts at once by providing a CSV. For more information, read [the documentation](https://github.com/medic/cht-conf/blob/master/README.md#editing-contacts-across-the-hierarchy).
+You can now bulk edit contacts at once by providing a CSV. For more information, read [the documentation](https://github.com/medic/cht-conf/blob/main/README.md#editing-contacts-across-the-hierarchy).
 
 [#297](https://github.com/medic/cht-conf/issues/297)
 

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ Breaking| perf(#2): remove reporting rates feature <br/> BREAKING CHANGE: report
 
 ### Releasing betas
 
-1. Checkout `master`
+1. Checkout the default branch, for example `main`
 1. Run `npm version --no-git-tag-version <major>.<minor>.<patch>-beta.1`. This will only update the versions in `package.json` and `package-lock.json`. It will not create a git tag and not create an associated commit.
 1. Run `npm publish --tag beta`. This will publish your beta tag to npm's beta channel.
 

--- a/release-notes.md
+++ b/release-notes.md
@@ -134,7 +134,7 @@ As of this release no docs on the server will be touched unless some configurati
 
 ### New action to bulk-edit contacts
 
-You can now bulk edit contacts at once by providing a CSV. For more information, read [the documentation](https://github.com/medic/cht-conf/blob/master/README.md#editing-contacts-across-the-hierarchy).
+You can now bulk edit contacts at once by providing a CSV. For more information, read [the documentation](https://github.com/medic/cht-conf/blob/main/README.md#editing-contacts-across-the-hierarchy).
 
 [#297](https://github.com/medic/cht-conf/issues/297)
 

--- a/src/fn/compress-svgs.js
+++ b/src/fn/compress-svgs.js
@@ -16,6 +16,6 @@ module.exports = {
           .then(() => svgo.optimize(fs.read(path), { path }))
           .then(result => fs.write(path, result.data))
           .then(() => trace('Compressed', path))
-          .then(() => warn('Make sure you compare the content of your SVG files before merging to the master branch - sometimes optimising can change their contents!')),
+          .then(() => warn('Make sure you compare the content of your SVG files before merging to the default branch - sometimes optimising can change their contents!')),
         Promise.resolve())
 };

--- a/src/lib/git-exec.js
+++ b/src/lib/git-exec.js
@@ -64,7 +64,7 @@ module.exports.getDefaultRemote = async () => {
 
 /**
  * Returns the upstream of the current branch,
- * in the form of repo/branch, eg. 'origin/master'.
+ * in the form of repo/branch, eg. 'origin/main'.
  *
  * Returns `null` if there are no upstreams repos configured.
  */

--- a/test/lib/git-exec.spec.js
+++ b/test/lib/git-exec.spec.js
@@ -48,28 +48,28 @@ describe('git-exec', () => {
   });
 
   it('`checkUpstream` with no upstream changes get empty result', async () => {
-    git.__set__('getUpstream', () => Promise.resolve('origin/master'));
+    git.__set__('getUpstream', () => Promise.resolve('origin/main'));
     git.__set__('exec', () => Promise.resolve('0\t0'));
     const result = await git.checkUpstream();
     expect(result).to.eq('');
   });
 
   it('`checkUpstream` with branch changes get text with result', async () => {
-    git.__set__('getUpstream', () => Promise.resolve('origin/master'));
+    git.__set__('getUpstream', () => Promise.resolve('origin/main'));
     git.__set__('exec', () => Promise.resolve('1\t0'));
     const result = await git.checkUpstream();
     expect(result).to.eq('branch is ahead upstream by 1 commit');
   });
 
   it('`checkUpstream` with upstream changes get text with result', async () => {
-    git.__set__('getUpstream', () => Promise.resolve('origin/master'));
+    git.__set__('getUpstream', () => Promise.resolve('origin/main'));
     git.__set__('exec', () => Promise.resolve('0\t2'));
     const result = await git.checkUpstream();
     expect(result).to.eq('branch is behind upstream by 2 commits');
   });
 
   it('`checkUpstream` with upstream and local branch changes get text with result', async () => {
-    git.__set__('getUpstream', () => Promise.resolve('origin/master'));
+    git.__set__('getUpstream', () => Promise.resolve('origin/main'));
     git.__set__('exec', () => Promise.resolve('2\t1'));
     const result = await git.checkUpstream();
     expect(result).to.eq('branch is behind upstream by 1 commit and ahead by 2 commits');


### PR DESCRIPTION
Changed a few files, both functional and notes, to stop referencing master branch and use main branch instead.

A few references to master were not updated as the main branch does not exist in those repos yet (for instance, cht-core)

# Description

[description]

medic/cht-conf#[number]

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
