### PR TITLE
feat(#484): add actions for validating forms

### DIFF
--- a/src/cli/usage.js
+++ b/src/cli/usage.js
@@ -63,6 +63,9 @@ ${bold('OPTIONS')}
   --skip-translation-check
     Skips checking message translations
 
+  --skip-validate
+    Skips form validation  
+
   --force
     CAN BE DANGEROUS! Passes yes to all commands and any where that would prompt to overwrite changes will overwrite automatically. 
 `);

--- a/src/fn/validate-app-forms.js
+++ b/src/fn/validate-app-forms.js
@@ -1,0 +1,7 @@
+const validateForms = require('../lib/validate-forms');
+const environment = require('../lib/environment');
+
+module.exports = {
+  requiresInstance: false,
+  execute: () => validateForms(environment.pathToProject, 'app', { forms: environment.extraArgs })
+};

--- a/src/fn/validate-app-forms.js
+++ b/src/fn/validate-app-forms.js
@@ -1,7 +1,12 @@
 const validateForms = require('../lib/validate-forms');
 const environment = require('../lib/environment');
 
+const validateAppForms = (forms) => {
+  return validateForms(environment.pathToProject, 'app', { forms });
+};
+
 module.exports = {
   requiresInstance: false,
-  execute: () => validateForms(environment.pathToProject, 'app', { forms: environment.extraArgs })
+  validateAppForms,
+  execute: () => validateAppForms(environment.extraArgs)
 };

--- a/src/fn/validate-collect-forms.js
+++ b/src/fn/validate-collect-forms.js
@@ -1,0 +1,7 @@
+const validateForms = require('../lib/validate-forms');
+const environment = require('../lib/environment');
+
+module.exports = {
+  requiresInstance: false,
+  execute: () => validateForms(environment.pathToProject, 'collect', { forms: environment.extraArgs })
+};

--- a/src/fn/validate-collect-forms.js
+++ b/src/fn/validate-collect-forms.js
@@ -1,7 +1,12 @@
 const validateForms = require('../lib/validate-forms');
 const environment = require('../lib/environment');
 
+const validateCollectForms = (forms) => {
+  return validateForms(environment.pathToProject, 'collect', { forms });
+};
+
 module.exports = {
   requiresInstance: false,
-  execute: () => validateForms(environment.pathToProject, 'collect', { forms: environment.extraArgs })
+  validateCollectForms,
+  execute: () => validateCollectForms(environment.extraArgs)
 };

--- a/src/fn/validate-contact-forms.js
+++ b/src/fn/validate-contact-forms.js
@@ -1,7 +1,12 @@
 const validateForms = require('../lib/validate-forms');
 const environment = require('../lib/environment');
 
+const validateContactForms = (forms) => {
+  return validateForms(environment.pathToProject, 'contact', { forms });
+};
+
 module.exports = {
   requiresInstance: false,
-  execute: () => validateForms(environment.pathToProject, 'contact', { forms: environment.extraArgs })
+  validateContactForms,
+  execute: () => validateContactForms(environment.extraArgs)
 };

--- a/src/fn/validate-contact-forms.js
+++ b/src/fn/validate-contact-forms.js
@@ -1,0 +1,7 @@
+const validateForms = require('../lib/validate-forms');
+const environment = require('../lib/environment');
+
+module.exports = {
+  requiresInstance: false,
+  execute: () => validateForms(environment.pathToProject, 'contact', { forms: environment.extraArgs })
+};

--- a/src/fn/watch-project.js
+++ b/src/fn/watch-project.js
@@ -5,6 +5,9 @@ const fs = require('fs');
 const { error, warn, info } = require('../lib/log');
 const Queue = require('queue-promise');
 const watcher = require('@parcel/watcher');
+const { validateAppForms } = require('./validate-app-forms');
+const { validateContactForms } = require('./validate-contact-forms');
+const { validateCollectForms } = require('./validate-collect-forms');
 const { uploadAppForms } = require('./upload-app-forms');
 const { uploadContactForms } = require('./upload-contact-forms');
 const { uploadCollectForms } = require('./upload-collect-forms');
@@ -26,6 +29,8 @@ const watcherEvents = {
 };
 
 const uploadInitialState = async (api) => {
+    await validateAppForms(environment.extraArgs);
+    await validateContactForms(environment.extraArgs);
     await uploadResources();
     await uploadAppForms(environment.extraArgs);
     await uploadContactForms(environment.extraArgs);
@@ -82,6 +87,7 @@ const processAppForm = (eventType, fileName) => {
     let form = uploadForms.formFileMatcher(fileName);
     if (form) {
         eventQueue.enqueue(async () => {
+            await validateAppForms([form]);
             await uploadAppForms([form]);
             return fileName;
         });
@@ -103,6 +109,7 @@ const processAppFormMedia = (formMediaDir, fileName) => {
     const form = uploadForms.formMediaMatcher(formMediaDir);
     if (form) {
         eventQueue.enqueue(async () => {
+            await validateAppForms([form]);
             await uploadAppForms([form]);
             return fileName;
         });
@@ -127,6 +134,7 @@ const processContactForm = (eventType, fileName) => {
     form = uploadForms.formFileMatcher(fileName);
     if (form) {
         eventQueue.enqueue(async () => {
+            await validateContactForms([form]);
             await uploadContactForms([form]);
             return fileName;
         });
@@ -142,6 +150,7 @@ const processCollectForm = (eventType, fileName) => {
     let form = uploadForms.formFileMatcher(fileName);
     if (form) {
         eventQueue.enqueue(async () => {
+            await validateCollectForms([form]);
             await uploadCollectForms([form]);
             return fileName;
         });

--- a/src/fn/watch-project.js
+++ b/src/fn/watch-project.js
@@ -28,10 +28,17 @@ const watcherEvents = {
     UpdateEvent: 'update'
 };
 
+const runValidation = async (validation, forms) => {
+    if(environment.skipValidate) {
+        return;
+    }
+    await validation(forms);
+};
+
 const uploadInitialState = async (api) => {
-    await validateAppForms(environment.extraArgs);
-    await validateContactForms(environment.extraArgs);
     await uploadResources();
+    await runValidation(validateAppForms, environment.extraArgs);
+    await runValidation(validateContactForms, environment.extraArgs);
     await uploadAppForms(environment.extraArgs);
     await uploadContactForms(environment.extraArgs);
     await uploadCustomTranslations();
@@ -87,7 +94,7 @@ const processAppForm = (eventType, fileName) => {
     let form = uploadForms.formFileMatcher(fileName);
     if (form) {
         eventQueue.enqueue(async () => {
-            await validateAppForms([form]);
+            await runValidation(validateAppForms, [form]);
             await uploadAppForms([form]);
             return fileName;
         });
@@ -109,7 +116,7 @@ const processAppFormMedia = (formMediaDir, fileName) => {
     const form = uploadForms.formMediaMatcher(formMediaDir);
     if (form) {
         eventQueue.enqueue(async () => {
-            await validateAppForms([form]);
+            await runValidation(validateAppForms,[form]);
             await uploadAppForms([form]);
             return fileName;
         });
@@ -134,7 +141,7 @@ const processContactForm = (eventType, fileName) => {
     form = uploadForms.formFileMatcher(fileName);
     if (form) {
         eventQueue.enqueue(async () => {
-            await validateContactForms([form]);
+            await runValidation(validateContactForms,[form]);
             await uploadContactForms([form]);
             return fileName;
         });
@@ -150,7 +157,7 @@ const processCollectForm = (eventType, fileName) => {
     let form = uploadForms.formFileMatcher(fileName);
     if (form) {
         eventQueue.enqueue(async () => {
-            await validateCollectForms([form]);
+            await runValidation(validateCollectForms,[form]);
             await uploadCollectForms([form]);
             return fileName;
         });

--- a/src/fn/watch-project.js
+++ b/src/fn/watch-project.js
@@ -28,11 +28,11 @@ const watcherEvents = {
     UpdateEvent: 'update'
 };
 
-const runValidation = async (validation, forms) => {
+const runValidation = (validation, forms) => {
     if(environment.skipValidate) {
         return;
     }
-    await validation(forms);
+    return validation(forms);
 };
 
 const uploadInitialState = async (api) => {

--- a/src/lib/environment.js
+++ b/src/lib/environment.js
@@ -12,7 +12,8 @@ const initialize = (
   extraArgs,
   apiUrl,
   force,
-  skipTranslationCheck
+  skipTranslationCheck,
+  skipValidate
 ) => {
   if (state.initialized) {
     throw Error('environment is already initialized');
@@ -26,7 +27,8 @@ const initialize = (
     isArchiveMode,
     pathToProject,
     force,
-    skipTranslationCheck
+    skipTranslationCheck,
+    skipValidate
   });
 };
 
@@ -51,6 +53,7 @@ module.exports = {
   get apiUrl() { return getState('apiUrl'); },
   get force() { return getState('force'); },
   get skipTranslationCheck() { return getState('skipTranslationCheck'); },
+  get skipValidate() { return getState('skipValidate'); },
 
   /**
    * Return `true` if the environment **seems** to be production.

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -157,9 +157,9 @@ module.exports = async (argv, env) => {
   //
   const projectName = fs.path.basename(pathToProject);
 
-  let apiUrl;
-  if (actions.some(action => action.requiresInstance)) {
-    apiUrl = getApiUrl(cmdArgs, env);
+  const apiUrl = getApiUrl(cmdArgs, env);
+  const requiresInstance = actions.some(action => action.requiresInstance);
+  if (requiresInstance) {
     if (!apiUrl) {
       throw new Error('Failed to obtain a url to the API');
     }
@@ -180,7 +180,7 @@ module.exports = async (argv, env) => {
     cmdArgs['skip-translation-check']
   );
 
-  if (apiUrl) {
+  if (requiresInstance && apiUrl) {
     await api().available();
   }
 

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -21,6 +21,9 @@ const defaultActions = [
   'convert-app-forms',
   'convert-collect-forms',
   'convert-contact-forms',
+  'validate-app-forms',
+  'validate-collect-forms',
+  'validate-contact-forms',
   'backup-all-forms',
   'delete-all-forms',
   'upload-app-forms',
@@ -38,6 +41,9 @@ const defaultArchiveActions = [
   'convert-app-forms',
   'convert-collect-forms',
   'convert-contact-forms',
+  'validate-app-forms',
+  'validate-collect-forms',
+  'validate-contact-forms',
   'upload-app-forms',
   'upload-collect-forms',
   'upload-contact-forms',
@@ -135,6 +141,16 @@ module.exports = async (argv, env) => {
   if (cmdArgs['skip-git-check']) {
     actions = actions.filter(a => a !== 'check-git');
   }
+
+  const addFormValidationIfNecessary = (formType) => {
+    const updateFormsIndex = actions.indexOf(`upload-${formType}-forms`);
+    if (updateFormsIndex >= 0 && actions.indexOf(`validate-${formType}-forms`) < 0) {
+      actions.splice(updateFormsIndex, 0, `validate-${formType}-forms`);
+    }
+  };
+  addFormValidationIfNecessary('app');
+  addFormValidationIfNecessary('collect');
+  addFormValidationIfNecessary('contact');
 
   actions = actions.map(actionName => {
     const action = require(`../fn/${actionName}`);

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -142,7 +142,8 @@ module.exports = async (argv, env) => {
     actions = actions.filter(a => a !== 'check-git');
   }
 
-  if(cmdArgs['skip-validate']) {
+  const skipValidate = cmdArgs['skip-validate'];
+  if(skipValidate) {
     warn('Skipping all form validation.');
     const validateActions = [
       'validate-app-forms',
@@ -203,7 +204,8 @@ module.exports = async (argv, env) => {
     extraArgs,
     apiUrl,
     cmdArgs.force,
-    cmdArgs['skip-translation-check']
+    cmdArgs['skip-translation-check'],
+    skipValidate
   );
 
   if (requiresInstance && apiUrl) {

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -123,13 +123,13 @@ module.exports = async (argv, env) => {
   // Build up actions
   //
   let actions = cmdArgs._;
-  if (!actions.length) {
+  if (actions.length) {
+    const unsupported = actions.filter(a => !supportedActions.includes(a));
+    if(unsupported.length) {
+      throw new Error(`Unsupported action(s): ${unsupported.join(' ')}`);
+    }
+  } else {
     actions = !cmdArgs.archive ? defaultActions : defaultArchiveActions;
-  }
-
-  const unsupported = actions.filter(a => !supportedActions.includes(a));
-  if(unsupported.length) {
-    throw new Error(`Unsupported action(s): ${unsupported.join(' ')}`);
   }
 
   if (cmdArgs['skip-git-check']) {

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -142,15 +142,25 @@ module.exports = async (argv, env) => {
     actions = actions.filter(a => a !== 'check-git');
   }
 
-  const addFormValidationIfNecessary = (formType) => {
-    const updateFormsIndex = actions.indexOf(`upload-${formType}-forms`);
-    if (updateFormsIndex >= 0 && actions.indexOf(`validate-${formType}-forms`) < 0) {
-      actions.splice(updateFormsIndex, 0, `validate-${formType}-forms`);
-    }
-  };
-  addFormValidationIfNecessary('app');
-  addFormValidationIfNecessary('collect');
-  addFormValidationIfNecessary('contact');
+  if(cmdArgs['skip-validate']) {
+    warn('Skipping all form validation.');
+    const validateActions = [
+      'validate-app-forms',
+      'validate-collect-forms',
+      'validate-contact-forms'
+    ];
+    actions = actions.filter(action => !validateActions.includes(action));
+  } else {
+    const addFormValidationIfNecessary = (formType) => {
+      const updateFormsIndex = actions.indexOf(`upload-${formType}-forms`);
+      if (updateFormsIndex >= 0 && actions.indexOf(`validate-${formType}-forms`) < 0) {
+        actions.splice(updateFormsIndex, 0, `validate-${formType}-forms`);
+      }
+    };
+    addFormValidationIfNecessary('app');
+    addFormValidationIfNecessary('collect');
+    addFormValidationIfNecessary('contact');
+  }
 
   actions = actions.map(actionName => {
     const action = require(`../fn/${actionName}`);

--- a/src/lib/upload-forms.js
+++ b/src/lib/upload-forms.js
@@ -13,7 +13,6 @@ const {
   readTitleFrom,
   readIdFrom
 } = require('./forms-utils');
-const validateForms = require('./validate-forms');
 
 const SUPPORTED_PROPERTIES = ['context', 'icon', 'title', 'xml2sms', 'subject_key', 'hidden_fields'];
 const FORM_EXTENSTION = '.xml';
@@ -40,7 +39,6 @@ const formMediaMatcher = (formMediaDir) => {
 };
 
 const execute = async (projectDir, subDirectory, options) => {
-  await validateForms(projectDir, subDirectory, options);
   const db = pouch();
   if (!options) options = {};
   const formsDir = getFormDir(projectDir, subDirectory);

--- a/src/lib/validate-forms.js
+++ b/src/lib/validate-forms.js
@@ -51,7 +51,7 @@ module.exports = async (projectDir, subDirectory, options={}) => {
   for(const fileName of fileNames) {
     log.info(`Validating form: ${fileName}…`);
 
-    const { xformPath } = getFormFilePaths(formsDir, fileName); //filePath
+    const { xformPath } = getFormFilePaths(formsDir, fileName);
     const xml = fs.read(xformPath);
 
     const valParams = { xformPath, xmlStr: xml };

--- a/src/lib/validate-forms.js
+++ b/src/lib/validate-forms.js
@@ -40,16 +40,16 @@ module.exports = async (projectDir, subDirectory, options={}) => {
     return;
   }
 
+  const instanceProvided = environment.apiUrl;
+  if(!instanceProvided) {
+    log.warn('Some validations have been skipped because they require a CHT instance.');
+  }
+
   const fileNames = argsFormFilter(formsDir, '.xml', options);
 
   let errorFound = false;
   for(const fileName of fileNames) {
     log.info(`Validating form: ${fileName}…`);
-
-    const instanceProvided = environment.apiUrl;
-    if(!instanceProvided) {
-      log.warn('Some validations have been skipped because they require a CHT instance.');
-    }
 
     const { xformPath } = getFormFilePaths(formsDir, fileName); //filePath
     const xml = fs.read(xformPath);

--- a/src/lib/validate-forms.js
+++ b/src/lib/validate-forms.js
@@ -41,9 +41,7 @@ module.exports = async (projectDir, subDirectory, options={}) => {
   }
 
   const instanceProvided = environment.apiUrl;
-  if(!instanceProvided) {
-    log.warn('Some validations have been skipped because they require a CHT instance.');
-  }
+  let validationSkipped = false;
 
   const fileNames = argsFormFilter(formsDir, '.xml', options);
 
@@ -57,6 +55,7 @@ module.exports = async (projectDir, subDirectory, options={}) => {
     const valParams = { xformPath, xmlStr: xml };
     for(const validation of validations) {
       if(validation.requiresInstance && !instanceProvided) {
+        validationSkipped = true;
         continue;
       }
 
@@ -74,6 +73,9 @@ module.exports = async (projectDir, subDirectory, options={}) => {
     }
   }
 
+  if(validationSkipped) {
+    log.warn('Some validations have been skipped because they require a CHT instance.');
+  }
   if(errorFound) {
     throw new Error('One or more forms have failed validation.');
   }

--- a/src/lib/validation/form/README.md
+++ b/src/lib/validation/form/README.md
@@ -6,8 +6,9 @@ Their module should look something like this:
 
 ```js
 module.exports = {
-  requiresInstance: true,
-  execute: async ({ xformPath, xmlStr, xmlDoc }) => {
+  requiresInstance: false,
+  skipFurtherValidation: true,
+  execute: async ({ xformPath, xmlStr }) => {
     ...
   }
 };
@@ -15,10 +16,11 @@ module.exports = {
 
 ## Module Exports
 
-| Field              | Required                     | Notes                                                                                                                                                 |
-|--------------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `requiresInstance` | Optional, defaults to `true` | The validation needs the user to have provided a instance location, e.g. via `--local` or `--instance`                                                |
-| `execute`          | Required                     | The function that is run when the validation is executed. The provided input argument contains the form XML data as both a string and a XML Document. |
+| Field                   | Required                       | Notes                                                                                                                                                                                                                                                        |
+|-------------------------|--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `requiresInstance`      | Optional, defaults to `true`   | The validation needs the user to have provided a instance location, e.g. via `--local` or `--instance`                                                                                                                                                       |
+| `skipFurtherValidation` | Optional, defaults to `false`  | When `true`, additional validations will not be performed on a form that fails the current validation. The goal is to avoid unnecessary noise in the validation log for forms that are grossly invalid (e.g. XML files that are not actually xForms at all). |
+| `execute`               | Required                       | The function that is run when the validation is executed. The provided input argument contains the form XML string.                                                                                                                                          |
 
 ## Result
 

--- a/src/lib/validation/form/README.md
+++ b/src/lib/validation/form/README.md
@@ -1,0 +1,30 @@
+# Form validations
+
+Form validations should be added to this directory.
+
+Their module should look something like this:
+
+```js
+module.exports = {
+  requiresInstance: true,
+  execute: async ({ xformPath, xmlStr, xmlDoc }) => {
+    ...
+  }
+};
+```
+
+## Module Exports
+
+| Field              | Required                     | Notes                                                                                                                                                 |
+|--------------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `requiresInstance` | Optional, defaults to `true` | The validation needs the user to have provided a instance location, e.g. via `--local` or `--instance`                                                |
+| `execute`          | Required                     | The function that is run when the validation is executed. The provided input argument contains the form XML data as both a string and a XML Document. |
+
+## Result
+
+The result has the following format:
+
+| Field    | Notes                                                                                              |
+|----------|----------------------------------------------------------------------------------------------------|
+| warnings | Array containing the descriptions of any warnings.                                                 |
+| errors   | Array containing the descriptions of any errors. If this is empty, the form has passed validation. |

--- a/src/lib/validation/form/can-generate-xform.js
+++ b/src/lib/validation/form/can-generate-xform.js
@@ -1,0 +1,25 @@
+const { formHasInstanceId } = require('../../forms-utils');
+const api = require('../../api');
+
+module.exports = {
+  requiresInstance: true,
+  execute: async ({ xformPath, xmlStr }) => {
+    const warnings = [];
+    const errors = [];
+
+    if(!formHasInstanceId(xmlStr)) {
+      return { errors, warnings };
+    }
+
+    try {
+      const resp = await api().formsValidate(xmlStr);
+      if (resp.formsValidateEndpointFound === false) {
+        warnings.push('Form validation endpoint not found in your version of CHT Core, no form will be checked before push');
+      }
+    } catch (err) {
+      errors.push(`Error found while validating "${xformPath}". Validation response: ${err.message}`);
+    }
+
+    return { errors, warnings };
+  }
+};

--- a/src/lib/validation/form/can-generate-xform.js
+++ b/src/lib/validation/form/can-generate-xform.js
@@ -1,16 +1,9 @@
-const { formHasInstanceId } = require('../../forms-utils');
 const api = require('../../api');
 
 module.exports = {
-  requiresInstance: true,
   execute: async ({ xformPath, xmlStr }) => {
     const warnings = [];
     const errors = [];
-
-    if(!formHasInstanceId(xmlStr)) {
-      return { errors, warnings };
-    }
-
     try {
       const resp = await api().formsValidate(xmlStr);
       if (resp.formsValidateEndpointFound === false) {

--- a/src/lib/validation/form/has-instance-id.js
+++ b/src/lib/validation/form/has-instance-id.js
@@ -1,0 +1,13 @@
+const { formHasInstanceId } = require('../../forms-utils');
+
+module.exports = {
+  requiresInstance: false,
+  execute: async ({ xformPath, xmlStr }) => {
+    const errors = [];
+    if(!formHasInstanceId(xmlStr)) {
+      errors.push(`Form at ${xformPath} appears to be missing <meta><instanceID/></meta> node. This form will not work on CHT webapp.`);
+    }
+
+    return { errors };
+  }
+};

--- a/src/lib/validation/form/has-instance-id.js
+++ b/src/lib/validation/form/has-instance-id.js
@@ -2,12 +2,13 @@ const { formHasInstanceId } = require('../../forms-utils');
 
 module.exports = {
   requiresInstance: false,
-  execute: async ({ xformPath, xmlStr }) => {
+  skipFurtherValidation: true,
+  execute: async({ xformPath, xmlStr }) => {
     const errors = [];
     if(!formHasInstanceId(xmlStr)) {
       errors.push(`Form at ${xformPath} appears to be missing <meta><instanceID/></meta> node. This form will not work on CHT webapp.`);
     }
 
-    return { errors };
+    return { errors, warnings: [] };
   }
 };

--- a/test/fn/watch-project.spec.js
+++ b/test/fn/watch-project.spec.js
@@ -87,6 +87,7 @@ describe('watch-project', function () {
     sinon.stub(environment, 'extraArgs').get(() => { });
     sinon.stub(environment, 'isArchiveMode').get(() => false);
     sinon.stub(environment, 'skipTranslationCheck').get(() => false);
+    sinon.stub(environment, 'skipValidate').get(() => false);
     sinon.stub(environment, 'force').get(() => false);
     return api.db.put({ _id: '_design/medic-client', deploy_info: { version: '3.5.0' } }).then(() => api.start());
   });
@@ -293,6 +294,24 @@ describe('watch-project', function () {
         expect(docIds).to.include(`form:contact:${form.replace('-', ':')}`);
       })
       .then(() => cleanFormDir(contactFormsDir, form));
+  });
+
+  it('watch-project: upload app forms --skip-validate', () => {
+    sinon.stub(environment, 'skipValidate').get(() => true);
+    const form = 'death';
+    const copySampleForm = () => {
+      copySampleForms('upload-app-form');
+    };
+
+    return watchWrapper(copySampleForm, `${form}.xml`)
+      .then(() => api.db.allDocs())
+      .then(docs => {
+        const docIds = docs.rows.map(row => row.id);
+        expect(docIds).to.include(`form:${form}`);
+        // No requests should have been made to the api since the validations were not run
+        expect(api.requestLog()).to.be.empty;
+      })
+      .then(() => cleanFormDir(appFormDir, form));
   });
 
 });

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -177,6 +177,33 @@ describe('main', () => {
     );
   });
 
+  it('--skip-validate for upload forms actions', async () => {
+    await main([...normalArgv, '--local', '--skip-validate', 'upload-collect-forms', 'upload-contact-forms', 'upload-app-forms'], {});
+    expectExecuteActionBehavior(
+      [
+        'upload-collect-forms',
+        'upload-contact-forms',
+        'upload-app-forms'
+      ], undefined
+    );
+    expect(mocks.warn.callCount).to.equal(1);
+    expect(mocks.warn.args[0][0]).to.equal('Skipping all form validation.');
+  });
+
+  it('--skip-validate for validate forms actions', async () => {
+    await main([...normalArgv, '--local', '--skip-validate', 'validate-collect-forms', 'validate-contact-forms',
+      'validate-app-forms', 'upload-collect-forms', 'upload-contact-forms', 'upload-app-forms'], {});
+    expectExecuteActionBehavior(
+      [
+        'upload-collect-forms',
+        'upload-contact-forms',
+        'upload-app-forms'
+      ], undefined
+    );
+    expect(mocks.warn.callCount).to.equal(1);
+    expect(mocks.warn.args[0][0]).to.equal('Skipping all form validation.');
+  });
+
   describe('--archive', () => {
     it('default actions', async () => {
       await main([...normalArgv, '--archive', '--destination=foo'], {});

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -189,6 +189,7 @@ describe('main', () => {
     );
     expect(mocks.warn.callCount).to.equal(1);
     expect(mocks.warn.args[0][0]).to.equal('Skipping all form validation.');
+    // The skipValidate param should be `true` when initializing the environment
     expect(mocks.environment.initialize.args[0][7]).to.eq(true);
   });
 
@@ -204,6 +205,7 @@ describe('main', () => {
     );
     expect(mocks.warn.callCount).to.equal(1);
     expect(mocks.warn.args[0][0]).to.equal('Skipping all form validation.');
+    // The skipValidate param should be `true` when initializing the environment
     expect(mocks.environment.initialize.args[0][7]).to.eq(true);
   });
 

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -175,6 +175,7 @@ describe('main', () => {
         'validate-app-forms', 'upload-app-forms'
       ], undefined
     );
+    expect(mocks.environment.initialize.args[0][7]).to.be.undefined;
   });
 
   it('--skip-validate for upload forms actions', async () => {
@@ -188,6 +189,7 @@ describe('main', () => {
     );
     expect(mocks.warn.callCount).to.equal(1);
     expect(mocks.warn.args[0][0]).to.equal('Skipping all form validation.');
+    expect(mocks.environment.initialize.args[0][7]).to.eq(true);
   });
 
   it('--skip-validate for validate forms actions', async () => {
@@ -202,6 +204,7 @@ describe('main', () => {
     );
     expect(mocks.warn.callCount).to.equal(1);
     expect(mocks.warn.args[0][0]).to.equal('Skipping all form validation.');
+    expect(mocks.environment.initialize.args[0][7]).to.eq(true);
   });
 
   describe('--archive', () => {

--- a/test/lib/main.spec.js
+++ b/test/lib/main.spec.js
@@ -119,7 +119,7 @@ describe('main', () => {
     expect(mocks.executeAction.args[0][0].name).to.eq('initialise-project-layout');
   });
 
-  const expectExecuteActionBehavior = (expectedActions, expectedExtraParams, needsApi) => {
+  const expectExecuteActionBehavior = (expectedActions, expectedExtraParams) => {
     if (Array.isArray(expectedActions)) {
       expect(mocks.executeAction.args.map(args => args[0].name)).to.deep.eq(expectedActions);
     } else {
@@ -128,18 +128,18 @@ describe('main', () => {
 
     expect(mocks.environment.initialize.args[0][3]).to.deep.eq(expectedExtraParams);
 
-    expect(mocks.environment.initialize.args[0][4]).to.eq(needsApi ? 'http://api' : undefined);
+    expect(mocks.environment.initialize.args[0][4]).to.eq('http://api');
   };
 
   it('--local no COUCH_URL', async () => {
     await main([...normalArgv, '--local'], {});
-    expectExecuteActionBehavior(defaultActions, undefined, true);
+    expectExecuteActionBehavior(defaultActions, undefined);
   });
 
   it('--local with COUCH_URL to localhost', async () => {
     const COUCH_URL = 'http://user:pwd@localhost:5988/medic';
     await main([...normalArgv, '--local'], { COUCH_URL });
-    expectExecuteActionBehavior(defaultActions, undefined, true);
+    expectExecuteActionBehavior(defaultActions, undefined);
   });
 
   it('--instance + 2 ordered actions', async () => {
@@ -166,6 +166,17 @@ describe('main', () => {
     }
   });
 
+  it('add validate forms actions for upload forms actions', async () => {
+    await main([...normalArgv, '--local', 'upload-collect-forms', 'upload-contact-forms', 'upload-app-forms'], {});
+    expectExecuteActionBehavior(
+      [
+        'validate-collect-forms', 'upload-collect-forms',
+        'validate-contact-forms', 'upload-contact-forms',
+        'validate-app-forms', 'upload-app-forms'
+      ], undefined
+    );
+  });
+
   describe('--archive', () => {
     it('default actions', async () => {
       await main([...normalArgv, '--archive', '--destination=foo'], {});
@@ -176,7 +187,7 @@ describe('main', () => {
 
     it('single action', async () => {
       await main([...normalArgv, '--archive', '--destination=foo', 'upload-app-settings'], {});
-      expectExecuteActionBehavior('upload-app-settings', undefined, true);
+      expectExecuteActionBehavior('upload-app-settings', undefined);
       expect(userPrompt.keyInYN.callCount).to.eq(0);
     });
 

--- a/test/lib/validate-forms.spec.js
+++ b/test/lib/validate-forms.spec.js
@@ -76,8 +76,8 @@ describe('validate-forms', () => {
       expect(logInfo.callCount).to.equal(1);
       expect(logInfo.args[0][0]).to.equal('Validating form: example.xml…');
       expect(logWarn.callCount).to.equal(2);
-      expect(logWarn.args[0][0]).to.equal('Some validations have been skipped because they require a CHT instance.');
-      expect(logWarn.args[1][0]).to.equal('Warning');
+      expect(logWarn.args[0][0]).to.equal('Warning');
+      expect(logWarn.args[1][0]).to.equal('Some validations have been skipped because they require a CHT instance.');
     });
   });
 

--- a/test/lib/validate-forms.spec.js
+++ b/test/lib/validate-forms.spec.js
@@ -3,95 +3,132 @@ const rewire = require('rewire');
 const sinon = require('sinon');
 
 const log = require('../../src/lib/log');
+const environment = require('../../src/lib/environment');
 
 const validateForms = rewire('../../src/lib/validate-forms');
-const xformGenerationValidation = rewire('../../src/lib/validation/form/can-generate-xform');
 
 const BASE_DIR = 'data/lib/upload-forms';
 const FORMS_SUBDIR = '.';
 
+const mockValidation = (output = {}) => ({
+  requiresInstance: true,
+  skipFurtherValidation: false,
+  execute: sinon.stub().resolves(output)
+});
+
 describe('validate-forms', () => {
+  let logInfo;
+  let logWarn;
+  let logError;
+
+  beforeEach(() => {
+    sinon.stub(environment, 'apiUrl').get(() => true);
+    logInfo = sinon.stub(log, 'info');
+    logWarn = sinon.stub(log, 'warn');
+    logError = sinon.stub(log, 'error');
+  });
 
   afterEach(sinon.restore);
 
-  it('should reject forms which do not have <meta><instanceID/></meta>', () => {
-    const logInfo = sinon.stub(log, 'info');
-    const logError = sinon.stub(log, 'error');
-    const apiMock = {
-      formsValidate: sinon.stub().resolves({ok:true})
-    };
-    return validateForms.__with__({api: apiMock})(async () => {
+  it('should properly load validations', () => {
+    const validations = validateForms.__get__('validations');
+
+    const hasInstanceId = validations.shift();
+    expect(hasInstanceId.name).to.equal('has-instance-id.js');
+    expect(hasInstanceId.requiresInstance).to.equal(false);
+    expect(hasInstanceId.skipFurtherValidation).to.equal(true);
+
+    const canGeneratexForm = validations.shift();
+    expect(canGeneratexForm.name).to.equal('can-generate-xform.js');
+    expect(canGeneratexForm.requiresInstance).to.equal(true);
+    expect(canGeneratexForm.skipFurtherValidation).to.equal(false);
+
+    expect(validations).to.be.empty;
+  });
+
+  it('should throw an error when there are validation errors', () => {
+    const errorValidation = mockValidation({ errors: ['Error 1', 'Error 2'] });
+    return validateForms.__with__({ validations: [errorValidation] })(async () => {
       try {
-        await validateForms(`${BASE_DIR}/no-instance-id`, FORMS_SUBDIR);
+        await validateForms(`${BASE_DIR}/good-and-bad-forms`, FORMS_SUBDIR);
         assert.fail('Expected Error to be thrown.');
       } catch (e) {
-        assert.notInclude(e.message, 'One or more forms appears to have errors found by the API validation endpoint.');
-        assert.include(e.message, 'One or more forms appears to be missing <meta><instanceID/></meta> node.');
-        expect(logInfo.args[0][0]).to.equal('Validating form: example.xml…');
-        expect(logError.callCount).to.equal(1);
+        assert.include(e.message, 'One or more forms have failed validation.');
+        expect(logInfo.callCount).to.equal(2);
+        expect(logInfo.args[0][0]).to.equal('Validating form: example-no-id.xml…');
+        expect(logInfo.args[1][0]).to.equal('Validating form: example.xml…');
+        expect(logError.callCount).to.equal(4);
+        expect(logError.args[0][0]).to.equal('Error 1');
+        expect(logError.args[1][0]).to.equal('Error 2');
+        expect(logError.args[2][0]).to.equal('Error 1');
+        expect(logError.args[3][0]).to.equal('Error 2');
       }
     });
   });
 
-  it('should reject forms that the api validations reject', () => {
-    const logInfo = sinon.stub(log, 'info');
-    const logError = sinon.stub(log, 'error');
-    const formsValidateMock = sinon.stub().rejects('The error');
-    const apiMock = () => ({
-      formsValidate: formsValidateMock
+  it('should warn when skipping validation that requires instance', () => {
+    sinon.stub(environment, 'apiUrl').get(() => false);
+    const errorValidation = mockValidation({ errors: ['Should not see this error.'] });
+    const warningValidation = mockValidation({ warnings: ['Warning'] });
+    warningValidation.requiresInstance = false;
+    return validateForms.__with__({ validations: [errorValidation, warningValidation] })(async () => {
+      await validateForms(`${BASE_DIR}/merge-properties`, FORMS_SUBDIR);
+      expect(logInfo.callCount).to.equal(1);
+      expect(logInfo.args[0][0]).to.equal('Validating form: example.xml…');
+      expect(logWarn.callCount).to.equal(2);
+      expect(logWarn.args[0][0]).to.equal('Some validations have been skipped because they require a CHT instance.');
+      expect(logWarn.args[1][0]).to.equal('Warning');
     });
-
-    return xformGenerationValidation.__with__({ api: apiMock })(
-      async () => validateForms.__with__({ xformGenerationValidation })(async () => {
-        try {
-          await validateForms(`${BASE_DIR}/merge-properties`, FORMS_SUBDIR);
-          assert.fail('Expected Error to be thrown.');
-        } catch (e) {
-          expect(formsValidateMock.called).to.be.true;
-          assert.include(e.message, 'One or more forms appears to have errors found by the API validation endpoint.');
-          assert.notInclude(e.message, 'One or more forms appears to be missing <meta><instanceID/></meta> node.');
-          expect(logInfo.args[0][0]).to.equal('Validating form: example.xml…');
-          expect(logError.callCount).to.equal(1);
-        }
-      })
-    );
   });
 
-  it('should execute all validations and fail with all the errors concatenated', () => {
-    const logInfo = sinon.stub(log, 'info');
-    const logError = sinon.stub(log, 'error');
-    const formsValidateMock = sinon.stub().rejects('The error');
-    const apiMock = () => ({
-      formsValidate: formsValidateMock
+  it('should skip additional validations for form when configured', () => {
+    const errorValidation = mockValidation({ errors: ['Error'] });
+    errorValidation.skipFurtherValidation = true;
+    const skippedValidation = mockValidation({ errors: ['Should not see this error.'] });
+    return validateForms.__with__({ validations: [errorValidation, skippedValidation] })(async () => {
+      try {
+        await validateForms(`${BASE_DIR}/good-and-bad-forms`, FORMS_SUBDIR);
+        assert.fail('Expected Error to be thrown.');
+      } catch (e) {
+        assert.include(e.message, 'One or more forms have failed validation.');
+        expect(logInfo.callCount).to.equal(2);
+        expect(logInfo.args[0][0]).to.equal('Validating form: example-no-id.xml…');
+        expect(logInfo.args[1][0]).to.equal('Validating form: example.xml…');
+        expect(logError.callCount).to.equal(2);
+        expect(logError.args[0][0]).to.equal('Error');
+        expect(logError.args[1][0]).to.equal('Error');
+      }
     });
-
-    return xformGenerationValidation.__with__({ api: apiMock })(
-      async () => validateForms.__with__({ xformGenerationValidation })(async () => {
-        try {
-          await validateForms(`${BASE_DIR}/good-and-bad-forms`, FORMS_SUBDIR);
-          assert.fail('Expected Error to be thrown.');
-        } catch (e) {
-          assert.include(e.message, 'One or more forms appears to have errors found by the API validation endpoint.');
-          assert.include(e.message, 'One or more forms appears to be missing <meta><instanceID/></meta> node.');
-          expect(logInfo.args[0][0]).to.equal('Validating form: example-no-id.xml…');
-          expect(logInfo.args[1][0]).to.equal('Validating form: example.xml…');
-          expect(logError.callCount).to.equal(2);
-        }
-      })
-    );
   });
 
   it('should resolve OK if all validations pass', () => {
-    const logInfo = sinon.stub(log, 'info');
-    const apiMock = () => ({
-      formsValidate: sinon.stub().resolves({ok:true})
+    return validateForms.__with__({ validations: [mockValidation(), mockValidation(), mockValidation()] })(async () => {
+      await validateForms(`${BASE_DIR}/merge-properties`, FORMS_SUBDIR);
+      expect(logInfo.callCount).to.equal(1);
+      expect(logInfo.args[0][0]).to.equal('Validating form: example.xml…');
     });
+  });
 
-    return xformGenerationValidation.__with__({ api: apiMock })(
-      async () => validateForms.__with__({ xformGenerationValidation })(async () => {
-        await validateForms(`${BASE_DIR}/merge-properties`, FORMS_SUBDIR);
-        expect(logInfo.args[0][0]).to.equal('Validating form: example.xml…');
-      })
-    );
+  it('should resolve OK if there are only warnings', () => {
+    const warningValidation = mockValidation({ warnings: ['Warning 1', 'Warning 2'] });
+    return validateForms.__with__({ validations: [warningValidation] })(async () => {
+      await validateForms(`${BASE_DIR}/good-and-bad-forms`, FORMS_SUBDIR);
+      expect(logInfo.callCount).to.equal(2);
+      expect(logInfo.args[0][0]).to.equal('Validating form: example-no-id.xml…');
+      expect(logInfo.args[1][0]).to.equal('Validating form: example.xml…');
+      expect(logWarn.callCount).to.equal(4);
+      expect(logWarn.args[0][0]).to.equal('Warning 1');
+      expect(logWarn.args[1][0]).to.equal('Warning 2');
+      expect(logWarn.args[2][0]).to.equal('Warning 1');
+      expect(logWarn.args[3][0]).to.equal('Warning 2');
+    });
+  });
+
+  it('should resolve OK if form directory cannot be found', () => {
+    return validateForms.__with__({ validations: [mockValidation(), mockValidation(), mockValidation()] })(async () => {
+      await validateForms(`${BASE_DIR}/non-existant-directory`, FORMS_SUBDIR);
+      expect(logInfo.callCount).to.equal(1);
+      expect(logInfo.args[0][0]).to.equal(`Forms dir not found: ${BASE_DIR}/non-existant-directory/forms/${FORMS_SUBDIR}`);
+    });
   });
 });

--- a/test/lib/validation/form/can-generate-xform.spec.js
+++ b/test/lib/validation/form/can-generate-xform.spec.js
@@ -1,0 +1,50 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+
+const canGenerateXForm = require('../../../../src/lib/validation/form/can-generate-xform');
+
+const api = require('../../../../src/lib/api');
+const environment = require('../../../../src/lib/environment');
+
+const xformPath = '/my/form/path/form.xml';
+const xmlStr = '<?xml version="1.0"?>';
+
+describe('can-generate-xform', () => {
+  beforeEach(() => {
+    sinon.stub(environment, 'isArchiveMode').get(() => false);
+  });
+
+  afterEach(sinon.restore);
+
+  it('should resolve OK when form has instance id', () => {
+    sinon.stub(api(), 'formsValidate').resolves({ formsValidateEndpointFound: true });
+
+    return canGenerateXForm.execute({ xformPath, xmlStr })
+      .then(output => {
+        expect(output.warnings).is.empty;
+        expect(output.errors).is.empty;
+      });
+  });
+
+  it('should return warning when forms validation endpoint not found', () => {
+    sinon.stub(api(), 'formsValidate').resolves({ formsValidateEndpointFound: false });
+
+    return canGenerateXForm.execute({ xformPath, xmlStr })
+      .then(output => {
+        expect(output.warnings).deep
+          .equals(['Form validation endpoint not found in your version of CHT Core, no form will be checked before push']);
+        expect(output.errors).is.empty;
+      });
+  });
+
+  it('should return error when forms validation endpoint not found', () => {
+    const err = new Error('Failed validation.');
+    sinon.stub(api(), 'formsValidate').throws(err);
+
+    return canGenerateXForm.execute({ xformPath, xmlStr })
+      .then(output => {
+        expect(output.warnings).is.empty;
+        expect(output.errors).deep.equals([`Error found while validating "${xformPath}". Validation response: ${err.message}`]);
+      });
+  });
+});

--- a/test/lib/validation/form/has-instance-id.spec.js
+++ b/test/lib/validation/form/has-instance-id.spec.js
@@ -1,0 +1,47 @@
+const { expect } = require('chai');
+
+const hasInstanceId = require('../../../../src/lib/validation/form/has-instance-id');
+
+const xformPath = '/my/form/path/form.xml';
+const getXml = (metaNodes = '') => `
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>No Instance ID</h:title>
+    <model>
+      <instance>
+        <data id="ABC" version="2015-06-05">
+          <name/>
+        </data>
+      </instance>
+      <bind nodeset="/data/name" type="string" />        
+      <meta>
+        ${metaNodes}
+      </meta>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/name">
+      <label>What is the name?</label>
+    </input>
+  </h:body>
+</h:html>`;
+
+describe('has-instance-id', () => {
+  it('should resolve OK when form has instance id', () => {
+    return hasInstanceId.execute({ xformPath, xmlStr: getXml('<instanceID/>') })
+      .then(output => {
+        expect(output.warnings).is.empty;
+        expect(output.errors).is.empty;
+      });
+  });
+
+  it('should return error when form does not have an instance id', () => {
+    return hasInstanceId.execute({ xformPath, xmlStr: getXml() })
+      .then(output => {
+        expect(output.warnings).is.empty;
+        expect(output.errors).deep
+          .equals([`Form at ${xformPath} appears to be missing <meta><instanceID/></meta> node. This form will not work on CHT webapp.`]);
+      });
+  });
+});


### PR DESCRIPTION
# Description

Adds new actions for validating app/collect/contact forms without calling the `validate-*-forms` actions.  Refactors the validate code to be modular so that it can be easily expanded in the future (following the same pattern as the cht-conf `actions`).  This is basically an implementation of [option A](https://github.com/medic/cht-conf/issues/481).

Also adds support for the `--skip-validate` flag which will cause all form validation to be totally skipped.

Closes #481

# Code review items

- [x] Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- [x] Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- [x] Tested: Unit and/or integration tests where appropriate
- [x] Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
