### PR TITLE
chore: Remove forum announcement from release steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,6 @@ Execute `npm test` to run static analysis checks and the test suite. Requires Do
 1. Get the pull request reviewed and approved.
 1. When doing the squash and merge, make sure that your commit message is clear and readable and follows the strict format described in the commit format section below. If the commit message does not comply, automatic release will fail.
 1. In case you are planning to merge the pull request with a merge commit, make sure that every commit in your branch respects the format. 
-1. Announce the release on the [CHT forum](https://forum.communityhealthtoolkit.org), under the "Product - Releases" category.
 
 ### Commit format
 The commit format should follow this [conventional-changelog angular preset](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular). Examples are provided below.


### PR DESCRIPTION
# Description

This step is no longer performed since we have updated this repo to be continuously deployed.

Context: [internal Slack discussion](https://medic.slack.com/archives/C03H77DKY0M/p1655933143379659).

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
