### PR TITLE
Add validation for simple XPaths in form config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1870,6 +1870,11 @@
         "@xtuc/long": "4.2.2"
       }
     },
+    "@xmldom/xmldom": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
+      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A=="
+    },
     "@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -2124,13 +2129,13 @@
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true
     },
     "array-from": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
       "dev": true
     },
     "array-ify": {
@@ -2851,7 +2856,7 @@
     "check-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
       "dev": true
     },
     "chokidar": {
@@ -4082,7 +4087,7 @@
     "double-ended-queue": {
       "version": "2.1.0-0",
       "resolved": "https://registry.npmjs.org/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz",
-      "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
+      "integrity": "sha512-+BNfZ+deCo8hMNpDqDnvT+c0XpJ5cUa6mqYq89bho2Ifze4URTqRkcwR399hWoTrTkbZ/XJYDgP6rc7pRgffEQ==",
       "dev": true
     },
     "dreamopt": {
@@ -4242,7 +4247,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
     },
     "end-of-stream": {
@@ -4452,7 +4457,7 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true
     },
     "escape-string-regexp": {
@@ -4812,7 +4817,7 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
     },
     "event-target-shim": {
@@ -5202,7 +5207,7 @@
     "fclone": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
-      "integrity": "sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA=",
+      "integrity": "sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw==",
       "dev": true
     },
     "fd-slicer": {
@@ -5501,7 +5506,7 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true
     },
     "from2": {
@@ -5680,7 +5685,7 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true
     },
     "get-intrinsic": {
@@ -5831,7 +5836,7 @@
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
-      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "integrity": "sha512-NknMLn7F2J7aflwFOlGdNIuCDpN3VGoSoB+aap3KABFWbHVn1TCgFC+np23J8W2BiZbjfEw3BFBycSMv1AFblg==",
       "dev": true,
       "requires": {
         "ini": "^1.3.4"
@@ -6849,7 +6854,7 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
       "dev": true
     },
     "isexe": {
@@ -7507,7 +7512,7 @@
     "ltgt": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
+      "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA==",
       "dev": true
     },
     "make-dir": {
@@ -7655,13 +7660,13 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true
     },
     "memdown": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
-      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "integrity": "sha512-iVrGHZB8i4OQfM155xx8akvG9FIj+ht14DX5CQkCTG4EHzZ3d3sgckIf/Lm9ivZalEsFuEVnWv2B2WZvbrro2w==",
       "dev": true,
       "requires": {
         "abstract-leveldown": "~2.7.1",
@@ -7754,7 +7759,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
     },
     "merge-stream": {
@@ -7792,7 +7797,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true
     },
     "micromatch": {
@@ -11183,7 +11188,7 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true
     },
     "path-type": {
@@ -15310,7 +15315,7 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
     },
     "uuid": {
@@ -15357,7 +15362,7 @@
     "vuvuzela": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/vuvuzela/-/vuvuzela-1.0.3.tgz",
-      "integrity": "sha1-O+FF5YJxxzylUnndhR8SpoIRSws=",
+      "integrity": "sha512-Tm7jR1xTzBbPW+6y1tknKiEhz04Wf/1iZkcTJjSFcpNko43+dFW6+OOeQe9taJIug3NdfUAjFKgUSyQrIKaDvQ==",
       "dev": true
     },
     "watchpack": {
@@ -15842,11 +15847,6 @@
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true
-    },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "xmlhttprequest": {
       "version": "1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1871,9 +1871,9 @@
       }
     },
     "@xmldom/xmldom": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.5.tgz",
-      "integrity": "sha512-V3BIhmY36fXZ1OtVcI9W+FxQqxVLsPKcNjWigIaa81dLC9IolJl5Mt4Cvhmr0flUnjSpTdrbMTSbXqYqV5dT6A=="
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.2.tgz",
+      "integrity": "sha512-+R0juSseERyoPvnBQ/cZih6bpF7IpCXlWbHRoCRzYzqpz6gWHOgf8o4MOEf6KBVuOyqU+gCNLkCWVIJAro8XyQ=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15863,6 +15863,11 @@
         "xmlhttprequest": ">=1.8.0"
       }
     },
+    "xpath": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "eslint": "eslint 'src/**/*.js' test/*.js 'test/**/*.js'",
     "docker-start-couchdb": "npm run docker-stop-couchdb && docker run -d -p 6984:5984 --rm --name cht-conf-couchdb couchdb:2.3.1 && sh test/scripts/wait_for_response_code.sh 6984 200 CouchDB",
     "docker-stop-couchdb": "docker stop cht-conf-couchdb || true",
-    "test": "npm run eslint && npm run docker-start-couchdb && npm run clean && mkdir -p build/test && cp -r test/data build/test/data && cd build/test && nyc --reporter=html mocha --forbid-only ../../test/**/*.spec.js && cd ../.. && npm run docker-stop-couchdb",
+    "test": "npm run eslint && npm run docker-start-couchdb && npm run clean && mkdir -p build/test && cp -r test/data build/test/data && cd build/test && nyc --reporter=html mocha --forbid-only \"../../test/**/*.spec.js\" && cd ../.. && npm run docker-stop-couchdb",
     "semantic-release": "semantic-release"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@hapi/joi": "^16.1.8",
     "@medic/translation-checker": "^1.0.1",
     "@parcel/watcher": "^2.0.5",
+    "@xmldom/xmldom": "^0.8.2",
     "canonical-json": "0.0.4",
     "csv-parse": "^4.16.0",
     "dom-compare": "^0.6.0",
@@ -67,7 +68,7 @@
     "terser-webpack-plugin": "^1.4.3",
     "uuid": "^8.3.2",
     "webpack": "^4.46.0",
-    "@xmldom/xmldom": "^0.8.2"
+    "xpath": "0.0.32"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.2.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "terser-webpack-plugin": "^1.4.3",
     "uuid": "^8.3.2",
     "webpack": "^4.46.0",
-    "xmldom": "^0.6.0"
+    "@xmldom/xmldom": "^0.7.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.2.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "terser-webpack-plugin": "^1.4.3",
     "uuid": "^8.3.2",
     "webpack": "^4.46.0",
-    "@xmldom/xmldom": "^0.7.0"
+    "@xmldom/xmldom": "^0.8.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^13.2.0",

--- a/src/lib/forms-utils.js
+++ b/src/lib/forms-utils.js
@@ -1,4 +1,11 @@
+const xpath = require('xpath');
 const fs = require('./sync-fs');
+
+const getNode = (currentNode, path) =>
+  xpath.parse(path).select1({ node: currentNode, allowAnyNamespaceForNoPrefix: true });
+
+const getNodes = (currentNode, path) =>
+  xpath.parse(path).select({ node: currentNode, allowAnyNamespaceForNoPrefix: true });
 
 module.exports = {
   /**
@@ -57,4 +64,34 @@ module.exports = {
       xml.match(/<model>[^]*<\/model>/)[0]
         .match(/<instance>[^]*<\/instance>/)[0]
         .match(/id="([^"]*)"/)[1],
+
+  /**
+   * Returns the node from the form XML specified by the given XPath.
+   * @param {Element} currentNode the current node in the form XML document
+   * @param {string} path the XPath expression
+   * @returns {Element} the selected node or `undefined` if not found
+   */
+  getNode,
+
+  /**
+   * Returns the nodes from the form XML specified by the given XPath.
+   * @param {Element} currentNode the current node in the form XML document
+   * @param {string} path the XPath expression
+   * @returns {Element} the selected nodes or an empty array if none are found
+   */
+  getNodes,
+
+  /**
+   * Returns the `bind` nodes for the given form XML.
+   * @param {Document} xmlDoc the form XML document
+   * @returns {Element}
+   */
+  getBindNodes: xmlDoc => getNodes(xmlDoc, '/h:html/h:head/model/bind'),
+
+  /**
+   * Returns the primary (first) `instance` node for the given form XML.
+   * @param {Document} xmlDoc the form XML document
+   * @returns {Element}
+   */
+  getPrimaryInstanceNode: xmlDoc => getNode(xmlDoc, '/h:html/h:head/model/instance'),
 };

--- a/src/lib/forms-utils.js
+++ b/src/lib/forms-utils.js
@@ -73,7 +73,7 @@ module.exports = {
    * @param {string} xmlDoc the XML document
    * @returns {boolean}
    */
-  formHasInstanceId: xmlDoc => getNode(xmlDoc, `${XPATH_MODEL}/meta/instanceID`) !== undefined,
+  formHasInstanceId: xmlDoc => getNode(xmlDoc, `//meta/instanceID`) !== undefined,
 
   // This isn't really how to parse XML, but we have fairly good control over the
   // input and this code is working so far.  This may break with changes to the

--- a/src/lib/forms-utils.js
+++ b/src/lib/forms-utils.js
@@ -1,6 +1,8 @@
 const xpath = require('xpath');
 const fs = require('./sync-fs');
 
+const XPATH_MODEL = '/h:html/h:head/model';
+
 const getNode = (currentNode, path) =>
   xpath.parse(path).select1({ node: currentNode, allowAnyNamespaceForNoPrefix: true });
 
@@ -36,35 +38,6 @@ module.exports = {
     };
   },
 
-  // This isn't really how to parse XML, but we have fairly good control over the
-  // input and this code is working so far.  This may break with changes to the
-  // formatting of output from xls2xform.
-
-  /**
-   * Check whether the XForm has the <instanceID/> tag.
-   * @param {string} xml the XML string
-   * @returns {boolean}
-   */
-  formHasInstanceId: xml => xml.includes('<instanceID/>'),
-
-  /**
-   * Get the title string inside the <h:title> tag
-   * @param {string} xml the XML string
-   * @returns {string}
-   */
-  readTitleFrom: xml =>
-      xml.substring(xml.indexOf('<h:title>') + 9, xml.indexOf('</h:title>')),
-
-  /**
-   * Get the ID of the form
-   * @param {string} xml the XML string
-   * @returns {string}
-   */
-  readIdFrom: xml =>
-      xml.match(/<model>[^]*<\/model>/)[0]
-        .match(/<instance>[^]*<\/instance>/)[0]
-        .match(/id="([^"]*)"/)[1],
-
   /**
    * Returns the node from the form XML specified by the given XPath.
    * @param {Element} currentNode the current node in the form XML document
@@ -86,12 +59,40 @@ module.exports = {
    * @param {Document} xmlDoc the form XML document
    * @returns {Element}
    */
-  getBindNodes: xmlDoc => getNodes(xmlDoc, '/h:html/h:head/model/bind'),
+  getBindNodes: xmlDoc => getNodes(xmlDoc, `${XPATH_MODEL}/bind`),
 
   /**
    * Returns the primary (first) `instance` node for the given form XML.
    * @param {Document} xmlDoc the form XML document
    * @returns {Element}
    */
-  getPrimaryInstanceNode: xmlDoc => getNode(xmlDoc, '/h:html/h:head/model/instance'),
+  getPrimaryInstanceNode: xmlDoc => getNode(xmlDoc, `${XPATH_MODEL}/instance`),
+
+  /**
+   * Check whether the XForm has the <instanceID/> tag.
+   * @param {string} xmlDoc the XML document
+   * @returns {boolean}
+   */
+  formHasInstanceId: xmlDoc => getNode(xmlDoc, `${XPATH_MODEL}/meta/instanceID`) !== undefined,
+
+  // This isn't really how to parse XML, but we have fairly good control over the
+  // input and this code is working so far.  This may break with changes to the
+  // formatting of output from xls2xform.
+  /**
+   * Get the title string inside the <h:title> tag
+   * @param {string} xml the XML string
+   * @returns {string}
+   */
+  readTitleFrom: xml =>
+    xml.substring(xml.indexOf('<h:title>') + 9, xml.indexOf('</h:title>')),
+
+  /**
+   * Get the ID of the form
+   * @param {string} xml the XML string
+   * @returns {string}
+   */
+  readIdFrom: xml =>
+    xml.match(/<model>[^]*<\/model>/)[0]
+      .match(/<instance>[^]*<\/instance>/)[0]
+      .match(/id="([^"]*)"/)[1],
 };

--- a/src/lib/validate-forms.js
+++ b/src/lib/validate-forms.js
@@ -1,3 +1,4 @@
+const { DOMParser } = require('@xmldom/xmldom');
 const argsFormFilter = require('./args-form-filter');
 const environment = require('./environment');
 const fs = require('./sync-fs');
@@ -7,6 +8,7 @@ const {
   getFormFilePaths
 } = require('./forms-utils');
 
+const domParser = new DOMParser();
 const VALIDATIONS_PATH = fs.path.resolve(__dirname, './validation/form');
 const validations = fs.readdir(VALIDATIONS_PATH)
   .filter(name => name.endsWith('.js'))
@@ -52,7 +54,7 @@ module.exports = async (projectDir, subDirectory, options={}) => {
     const { xformPath } = getFormFilePaths(formsDir, fileName);
     const xml = fs.read(xformPath);
 
-    const valParams = { xformPath, xmlStr: xml };
+    const valParams = { xformPath, xmlStr: xml, xmlDoc: domParser.parseFromString(xml) };
     for(const validation of validations) {
       if(validation.requiresInstance && !instanceProvided) {
         validationSkipped = true;

--- a/src/lib/validation/form/check-xpaths-exist.js
+++ b/src/lib/validation/form/check-xpaths-exist.js
@@ -14,11 +14,19 @@ https://github.com/medic/cht-conf/issues/479
 
 const { getNode, getBindNodes, getPrimaryInstanceNode } = require('../../forms-utils');
 
+// Characters used in simple XPaths
 const SUPPORTED_CHAR = '[/\\w.-]';
+// Special characters used in complex XPaths
 const UNSUPPORTED_CHAR = '[*@:[\\]]';
 const XPATH_CHAR = `(${SUPPORTED_CHAR}|${UNSUPPORTED_CHAR})`;
-const UNSUPPORTED_XPATH_PATTERN = new RegExp(`\\/\\/|${UNSUPPORTED_CHAR}`, 'g');
-const XPATH_PATTERN = new RegExp(`${XPATH_CHAR}*\\/${XPATH_CHAR}+`, 'g');
+// Some XPaths lookup nodes in separate instances (e.g. instance('contact-summary')/context/pregnancy_uuid)
+const INSTANCE = `instance\\([\\w-'"]+\\)`;
+// Look ahead and make sure there are an even number of quotes following the match (this means that the match itself is not in quotes).
+const LOOK_AHEADS_FOR_EVEN_QUOTES = `(?=([^"]*"[^"]*")*[^"]*$)(?=([^']*'[^']*')*[^']*$)`;
+// Matches on all possible XPaths (simple and complex) not in quotes. May start with an instance reference. Must include a slash.
+const XPATH_PATTERN = new RegExp(`(${INSTANCE}|)${XPATH_CHAR}*\\/${XPATH_CHAR}+${LOOK_AHEADS_FOR_EVEN_QUOTES}`, 'g');
+// Matches on XPaths containing complex calculations (note that '//' indicates a deep lookup, which we do not validate)
+const UNSUPPORTED_XPATH_PATTERN = new RegExp(`\\/\\/|${UNSUPPORTED_CHAR}|${INSTANCE}`, 'g');
 
 const extractSimpleXpaths = (expression) => {
   /*

--- a/src/lib/validation/form/check-xpaths-exist.js
+++ b/src/lib/validation/form/check-xpaths-exist.js
@@ -1,0 +1,107 @@
+/*
+An XPath expression that evaluates to an empty result (e.g. no node is found in the document that matches the
+expression) is technically "valid" (in the sense that it is a properly formatted XPath expression).
+
+However, if there is a "simple" XPath expression (one that just references a node via an absolute/relative path and does
+not contain any dynamic processing) in a form that does not evaluate to an actual node in the form, that is almost
+certainly an error (since it could never return any other result). This validation checks the simple XPaths in a form's
+calculate, constraint, readonly, relevant, and required expressions and returns an error for any simple XPaths that
+point to a non-existant node. More complex dynamic XPath expressions are not validated (since their results could vary
+at runtime depending on the data in the form).
+*/
+
+const { getNode, getBindNodes, getPrimaryInstanceNode } = require('../../forms-utils');
+
+// TODO Refactor and document
+const XPATH_SPECIAL_CHARS = /\/\/|[*@:[\]]/g;
+const XPATH_PATTERN = /[/\w.*@:[\]-]*\/[/\w.*@:[\]-]+/g;
+
+const extractSimpleXpaths = (expression) => {
+  return (expression.match(XPATH_PATTERN) || [])
+    .filter(xpath => xpath.startsWith('/') || xpath.startsWith('./') || xpath.startsWith('../'))
+    .filter(xpath => !xpath.match(XPATH_SPECIAL_CHARS));
+};
+
+const isValidXpath = (nodeset, xpathToValidate, instance) => {
+  if(xpathToValidate.startsWith('/')) {
+    // Absolute XPath. Evaluate it relative to the instance
+    return getNode(instance, xpathToValidate.substring(1));
+  }
+
+  // Relative XPath. Evaluate it relative to the current node
+  const currentNode = getNode(instance, nodeset.substring(1));
+  if(!currentNode) {
+    throw new Error(`Could not find model node referenced by bind nodeset: ${nodeset}`);
+  }
+
+  return getNode(currentNode, xpathToValidate);
+};
+
+const extractInvalidXPaths = (nodeset, expression, instance) => {
+  return extractSimpleXpaths(expression)
+    .filter(xpath => !isValidXpath(nodeset, xpath, instance));
+};
+
+const getField = (bind, instance) => {
+  const nodeset = bind.getAttribute('nodeset');
+  const getInvalidXPaths = (expression) => extractInvalidXPaths(nodeset, expression, instance);
+
+  return {
+    nodeset,
+    calculate: getInvalidXPaths(bind.getAttribute('calculate')),
+    constraint: getInvalidXPaths(bind.getAttribute('constraint')),
+    readonly: getInvalidXPaths(bind.getAttribute('readonly')),
+    relevant: getInvalidXPaths(bind.getAttribute('relevant')),
+    required: getInvalidXPaths(bind.getAttribute('required')),
+  };
+};
+
+const keepFieldsWithXPaths = (field) => {
+  return field.calculate.length ||
+    field.constraint.length ||
+    field.readonly.length ||
+    field.relevant.length ||
+    field.required.length;
+};
+
+const getFieldsWithInvalidXPaths = (xmlDoc) => {
+  const instance = getPrimaryInstanceNode(xmlDoc);
+  if(!instance) {
+    throw new Error('No instance found in form XML.');
+  }
+  return getBindNodes(xmlDoc)
+    .map(bind => getField(bind, instance))
+    .filter(field => keepFieldsWithXPaths(field));
+};
+
+module.exports = {
+  requiresInstance: false,
+  skipFurtherValidation: false,
+  execute: async({ xformPath, xmlDoc }) => {
+    const errors = [];
+    try {
+      const fields = getFieldsWithInvalidXPaths(xmlDoc);
+      if(fields.length) {
+        errors.push(`Form at ${xformPath} contains invalid XPath expressions (absolute or relative paths that refer to a non-existant node):`);
+
+        fields.forEach(field => {
+          const recordError = (expressionName) => {
+            const xpaths = field[expressionName];
+            if(xpaths.length) {
+              errors.push(`  - ${expressionName} for ${field.nodeset} contains ${xpaths}`);
+            }
+          };
+          recordError('calculate');
+          recordError('constraint');
+          recordError('readonly');
+          recordError('relevant');
+          recordError('required');
+        });
+      }
+    } catch(e) {
+      errors.push(`Error encountered while validating XPaths in form at ${xformPath}: ${e.message}`);
+    }
+
+    return { errors, warnings: [] };
+  }
+};

--- a/src/lib/validation/form/has-instance-id.js
+++ b/src/lib/validation/form/has-instance-id.js
@@ -3,9 +3,9 @@ const { formHasInstanceId } = require('../../forms-utils');
 module.exports = {
   requiresInstance: false,
   skipFurtherValidation: true,
-  execute: async({ xformPath, xmlStr }) => {
+  execute: async({ xformPath, xmlDoc }) => {
     const errors = [];
-    if(!formHasInstanceId(xmlStr)) {
+    if(!formHasInstanceId(xmlDoc)) {
       errors.push(`Form at ${xformPath} appears to be missing <meta><instanceID/></meta> node. This form will not work on CHT webapp.`);
     }
 

--- a/src/lib/warn-upload-overwrite.js
+++ b/src/lib/warn-upload-overwrite.js
@@ -8,7 +8,7 @@ const path = require('path');
 const log = require('./log');
 const environment = require('./environment');
 const { compare, GroupingReporter } = require('dom-compare');
-const DOMParser = require('xmldom').DOMParser;
+const DOMParser = require('@xmldom/xmldom').DOMParser;
 
 const question = 'You are trying to modify a configuration that has been modified since your last upload. Do you want to?';
 const responseChoicesWithoutDiff = [

--- a/test/lib/forms-utils.spec.js
+++ b/test/lib/forms-utils.spec.js
@@ -1,0 +1,109 @@
+const { expect } = require('chai');
+const path = require('path');
+const formUtils = require('../../src/lib/forms-utils');
+
+const getXml = (opts = { metaNodes: '<instanceID/>', title: 'Has Instance ID', id: 'ABC' }) => `
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>${opts.title}</h:title>
+    <model>
+      <instance>
+        <data id="${opts.id}" version="2015-06-05">
+          <name>Billy Bob</name>
+          <age/>
+        </data>
+      </instance>
+      <bind nodeset="/data/name" type="string" />
+      <bind nodeset="/data/age" type="int" relevant="/data/name != ''" />        
+      <meta>
+        ${opts.metaNodes}
+      </meta>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/name">
+      <label>What is the name?</label>
+    </input>
+    <input ref="/data/age">
+      <label>What is the age?</label>
+    </input>
+  </h:body>
+</h:html>`;
+
+const projectDir = path.join(__dirname, '../data/convert-app-forms');
+
+describe('form-utils', () => {
+  describe('getFormDir', () => {
+    it('returns the form directory path when it exists', () => {
+      const formDir = formUtils.getFormDir(projectDir, 'app');
+      expect(formDir).to.equal(`${projectDir}/forms/app`);
+    });
+
+    it('returns null when the form directory does not exist', () => {
+      const formDir = formUtils.getFormDir(projectDir, 'non-existent-dir');
+      expect(formDir).to.equal(null);
+    });
+
+    it('returns null when the project directory does not exist', () => {
+      const formDir = formUtils.getFormDir('non-existent-dir', 'app');
+      expect(formDir).to.equal(null);
+    });
+  });
+
+  describe('getFormFilePaths', () => {
+    const formDir = `${projectDir}/forms/app`;
+
+    it('returns the file path data for a file name with extension', () => {
+      const pathData = formUtils.getFormFilePaths(formDir, 'delivery.xml');
+      expect(pathData.baseFileName).to.equal('delivery');
+      expect(pathData.mediaDir).to.equal(`${formDir}/delivery-media`);
+      expect(pathData.xformPath).to.equal(`${formDir}/delivery.xml`);
+      expect(pathData.filePath).to.equal(`${formDir}/delivery.xml`);
+    });
+
+    it('returns the file path data for a file name without extension', () => {
+      const pathData = formUtils.getFormFilePaths(formDir, 'delivery');
+      expect(pathData.baseFileName).to.equal('delivery');
+      expect(pathData.mediaDir).to.equal(`${formDir}/delivery-media`);
+      expect(pathData.xformPath).to.equal(`${formDir}/delivery.xml`);
+      expect(pathData.filePath).to.equal(`${formDir}/delivery`);
+    });
+  });
+
+  describe('formHasInstanceId', () => {
+    it('returns true when the form has an instance ID', () => {
+      const hasInstanceId = formUtils.formHasInstanceId(getXml());
+      expect(hasInstanceId).to.equal(true);
+    });
+
+    it('returns false when the form does not have an instance ID', () => {
+      const hasInstanceId = formUtils.formHasInstanceId(getXml({ metaNodes: '' }));
+      expect(hasInstanceId).to.equal(false);
+    });
+  });
+
+  describe('readTitleFrom', () => {
+    it('returns the title when the form has a title', () => {
+      const title = formUtils.readTitleFrom(getXml());
+      expect(title).to.equal('Has Instance ID');
+    });
+
+    it('returns an empty string when the form title is empty', () => {
+      const title = formUtils.readTitleFrom(getXml({ title: '' }));
+      expect(title).to.equal('');
+    });
+  });
+
+  describe('readIdFrom', () => {
+    it('returns the id when the form has an id', () => {
+      const id = formUtils.readIdFrom(getXml());
+      expect(id).to.equal('ABC');
+    });
+
+    it('returns an empty string when the form id is empty', () => {
+      const id = formUtils.readIdFrom(getXml({ id: '' }));
+      expect(id).to.equal('');
+    });
+  });
+});

--- a/test/lib/forms-utils.spec.js
+++ b/test/lib/forms-utils.spec.js
@@ -83,37 +83,13 @@ describe('form-utils', () => {
 
   describe('formHasInstanceId', () => {
     it('returns true when the form has an instance ID', () => {
-      const hasInstanceId = formUtils.formHasInstanceId(getXml());
+      const hasInstanceId = formUtils.formHasInstanceId(getXmlDoc());
       expect(hasInstanceId).to.equal(true);
     });
 
     it('returns false when the form does not have an instance ID', () => {
-      const hasInstanceId = formUtils.formHasInstanceId(getXml({ metaNodes: '' }));
+      const hasInstanceId = formUtils.formHasInstanceId(getXmlDoc({ metaNodes: '' }));
       expect(hasInstanceId).to.equal(false);
-    });
-  });
-
-  describe('readTitleFrom', () => {
-    it('returns the title when the form has a title', () => {
-      const title = formUtils.readTitleFrom(getXml());
-      expect(title).to.equal('Has Instance ID');
-    });
-
-    it('returns an empty string when the form title is empty', () => {
-      const title = formUtils.readTitleFrom(getXml({ title: '' }));
-      expect(title).to.equal('');
-    });
-  });
-
-  describe('readIdFrom', () => {
-    it('returns the id when the form has an id', () => {
-      const id = formUtils.readIdFrom(getXml());
-      expect(id).to.equal('ABC');
-    });
-
-    it('returns an empty string when the form id is empty', () => {
-      const id = formUtils.readIdFrom(getXml({ id: '' }));
-      expect(id).to.equal('');
     });
   });
 
@@ -192,6 +168,30 @@ describe('form-utils', () => {
     it('returns undefined when no instance nodes exist', () => {
       const node = formUtils.getPrimaryInstanceNode(domParser.parseFromString(emptyXml));
       expect(node).to.be.undefined;
+    });
+  });
+
+  describe('readTitleFrom', () => {
+    it('returns the title when the form has a title', () => {
+      const title = formUtils.readTitleFrom(getXml());
+      expect(title).to.equal('Has Instance ID');
+    });
+
+    it('returns an empty string when the form title is empty', () => {
+      const title = formUtils.readTitleFrom(getXml({ title: '' }));
+      expect(title).to.equal('');
+    });
+  });
+
+  describe('readIdFrom', () => {
+    it('returns the id when the form has an id', () => {
+      const id = formUtils.readIdFrom(getXml());
+      expect(id).to.equal('ABC');
+    });
+
+    it('returns an empty string when the form id is empty', () => {
+      const id = formUtils.readIdFrom(getXml({ id: '' }));
+      expect(id).to.equal('');
     });
   });
 });

--- a/test/lib/validate-forms.spec.js
+++ b/test/lib/validate-forms.spec.js
@@ -44,6 +44,11 @@ describe('validate-forms', () => {
     expect(canGeneratexForm.requiresInstance).to.equal(true);
     expect(canGeneratexForm.skipFurtherValidation).to.equal(false);
 
+    const checkXPathsExist = validations.shift();
+    expect(checkXPathsExist.name).to.equal('check-xpaths-exist.js');
+    expect(checkXPathsExist.requiresInstance).to.equal(false);
+    expect(checkXPathsExist.skipFurtherValidation).to.equal(false);
+
     expect(validations).to.be.empty;
   });
 

--- a/test/lib/validation/form/check-xpaths-exist.spec.js
+++ b/test/lib/validation/form/check-xpaths-exist.spec.js
@@ -1,0 +1,122 @@
+const { expect } = require('chai');
+const { DOMParser } = require('@xmldom/xmldom');
+const checkXPathsExist = require('../../../../src/lib/validation/form/check-xpaths-exist');
+
+const domParser = new DOMParser();
+
+const getXml = (bindData = '') => `
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <h:head>
+    <h:title>No Instance ID</h:title>
+    <model>
+      <instance>
+        <data id="ABC" version="2015-06-05">
+          <name>Harambe</name>
+          <age/>
+          <address>
+            <street-nbr/>
+          </address>
+          <summary>
+            <summary_title>Summary</summary_title>
+            <details/>
+          </summary>
+        </data>
+      </instance>
+      ${bindData}
+      <meta>
+        <instanceID/>
+      </meta>
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/name">
+      <label>What is the name?</label>
+    </input>
+    <input ref="/data/age">
+      <label>What is the age?</label>
+    </input>
+  </h:body>
+</h:html>`;
+
+const createBindData = fields =>
+  fields
+    .map(({ name, type, calculate }) => {
+      const calc = calculate ? `calculate="${calculate}"` : '';
+      return `<bind nodeset="${name}" type="${type}" ${calc}/>`;
+    })
+    .join('');
+
+const getXmlDoc = (fields) => domParser.parseFromString(getXml(createBindData(fields)));
+const xformPath = '/my/form/path/form.xml';
+
+const assertEmpty = (output) => {
+  expect(output.warnings).is.empty;
+  expect(output.errors, output.errors).is.empty;
+};
+
+
+describe('check-xpaths-exist', () => {
+  [
+    'calculate',
+    'constraint',
+    'readonly',
+    'relevant',
+    'required'
+  ].forEach((attribute) => {
+    [
+      '/data',
+      '/data/name',
+      '/data/summary/summary_title',
+      '../summary_title',
+      '../../name',
+      '../../address/street-nbr',
+      '../../address/../../data',
+      `concat(/data/name, 'ebmarah', ../../name)`,
+      '0 and explode(/data) + explode(explode(explode(1, 2, 3, explode(), ../../name)))'
+    ].forEach(xpath => {
+      it(`resolves OK for ${attribute} with valid XPath(s) [${xpath}]`, () => {
+        const fields = [ { name: '/data/summary/details', type: 'string', [attribute]: xpath } ];
+        return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
+          .then(output => assertEmpty(output));
+      });
+    });
+
+    [
+      `'coalesce(self::*, '../summary_title')'`,
+      'child::*/attribute::*',
+      'bookstore/*/title',
+      'book/*/last-name',
+      '*/*',
+      '@*',
+      '@my:*',
+      'my:*',
+      '/model/instance[1]/*//*[@template] | /model/instance[1]/*//*[@jr:template]',
+      `/bk:books/bk:book[@name = 'Harry Potter and the Half-Blood Prince']/hp:characters`,
+      '/bk:book/hp:characters',
+      '/characters/character[@greeting = $greeting]',
+      `/model/instance[1]/nested_repeats/kids/has_kids='2'`,
+      '/data/p[2] * /data/p[3]',
+      'ancestor-or-self::* /ancestor-or-self::*',
+      'author',
+      'first.name',
+      '//author',
+      'author/first-name',
+      'bookstore//title',
+      'bookstore//book/excerpt//emph',
+      './/title',
+      '@style',
+      'price/@exchange',
+    ].forEach(xpath => {
+      it(`resolves OK for ${attribute} with invalid complex XPath(s) [${xpath}]`, () => {
+        const fields = [ { name: '/data/summary/details', type: 'string', [attribute]: xpath } ];
+        return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
+          .then(output => assertEmpty(output));
+      });
+    });
+
+
+  });
+});
+
+// TODO include test where calculate/etc exist  but are empty

--- a/test/lib/validation/form/check-xpaths-exist.spec.js
+++ b/test/lib/validation/form/check-xpaths-exist.spec.js
@@ -4,13 +4,13 @@ const checkXPathsExist = require('../../../../src/lib/validation/form/check-xpat
 
 const domParser = new DOMParser();
 
-const getXml = (bindData = '') => `
+const getXml = (bindData = '', instanceTag = 'instance') => `
 <?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <h:head>
-    <h:title>No Instance ID</h:title>
+    <h:title>Test</h:title>
     <model>
-      <instance>
+      <${instanceTag}>
         <data id="ABC" version="2015-06-05">
           <name>Harambe</name>
           <age/>
@@ -22,7 +22,8 @@ const getXml = (bindData = '') => `
             <details/>
           </summary>
         </data>
-      </instance>
+      </${instanceTag}>
+      <${instanceTag} id="contact-summary"/>
       ${bindData}
       <meta>
         <instanceID/>
@@ -41,13 +42,17 @@ const getXml = (bindData = '') => `
 
 const createBindData = fields =>
   fields
-    .map(({ name, type, calculate }) => {
+    .map(({ name, type, calculate, constraint, readonly, relevant, required }) => {
       const calc = calculate ? `calculate="${calculate}"` : '';
-      return `<bind nodeset="${name}" type="${type}" ${calc}/>`;
+      const cons = constraint ? `constraint="${constraint}"` : '';
+      const read = readonly ? `readonly="${readonly}"` : '';
+      const rel = relevant ? `relevant="${relevant}"` : '';
+      const req = required ? `required="${required}"` : '';
+      return `<bind nodeset="${name}" type="${type}" ${calc} ${cons} ${read} ${rel} ${req}/>`;
     })
     .join('');
 
-const getXmlDoc = (fields) => domParser.parseFromString(getXml(createBindData(fields)));
+const getXmlDoc = (fields, instance) => domParser.parseFromString(getXml(createBindData(fields), instance));
 const xformPath = '/my/form/path/form.xml';
 
 const assertEmpty = (output) => {
@@ -55,6 +60,7 @@ const assertEmpty = (output) => {
   expect(output.errors, output.errors).is.empty;
 };
 
+const ERROR_HEADER = `Form at ${xformPath} contains invalid XPath expressions (absolute or relative paths that refer to a non-existant node):`;
 
 describe('check-xpaths-exist', () => {
   [
@@ -64,59 +70,202 @@ describe('check-xpaths-exist', () => {
     'relevant',
     'required'
   ].forEach((attribute) => {
-    [
-      '/data',
-      '/data/name',
-      '/data/summary/summary_title',
-      '../summary_title',
-      '../../name',
-      '../../address/street-nbr',
-      '../../address/../../data',
-      `concat(/data/name, 'ebmarah', ../../name)`,
-      '0 and explode(/data) + explode(explode(explode(1, 2, 3, explode(), ../../name)))'
-    ].forEach(xpath => {
-      it(`resolves OK for ${attribute} with valid XPath(s) [${xpath}]`, () => {
-        const fields = [ { name: '/data/summary/details', type: 'string', [attribute]: xpath } ];
-        return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
-          .then(output => assertEmpty(output));
-      });
+    it(`resolves OK for ${attribute} with valid XPath`, () => {
+      const fields = [{ name: '/data/summary/details', type: 'string', [attribute]: '/data/summary/summary_title' }];
+      return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
+        .then(output => assertEmpty(output));
     });
 
-    [
-      `'coalesce(self::*, '../summary_title')'`,
-      'child::*/attribute::*',
-      'bookstore/*/title',
-      'book/*/last-name',
-      '*/*',
-      '@*',
-      '@my:*',
-      'my:*',
-      '/model/instance[1]/*//*[@template] | /model/instance[1]/*//*[@jr:template]',
-      `/bk:books/bk:book[@name = 'Harry Potter and the Half-Blood Prince']/hp:characters`,
-      '/bk:book/hp:characters',
-      '/characters/character[@greeting = $greeting]',
-      `/model/instance[1]/nested_repeats/kids/has_kids='2'`,
-      '/data/p[2] * /data/p[3]',
-      'ancestor-or-self::* /ancestor-or-self::*',
-      'author',
-      'first.name',
-      '//author',
-      'author/first-name',
-      'bookstore//title',
-      'bookstore//book/excerpt//emph',
-      './/title',
-      '@style',
-      'price/@exchange',
-    ].forEach(xpath => {
-      it(`resolves OK for ${attribute} with invalid complex XPath(s) [${xpath}]`, () => {
-        const fields = [ { name: '/data/summary/details', type: 'string', [attribute]: xpath } ];
-        return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
-          .then(output => assertEmpty(output));
-      });
+    it(`resolves OK for ${attribute} with invalid complex XPath`, () => {
+      const fields = [{
+        name: '/data/summary/details',
+        type: 'string',
+        [attribute]: '/characters/character[@greeting = $greeting]'
+      }];
+      return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
+        .then(output => assertEmpty(output));
     });
 
+    it(`returns error for ${attribute} with invalid simple XPath`, () => {
+      const fields = [{ name: '/data/summary/details', type: 'string', [attribute]: '/data/summary/invalid' }];
+      return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
+        .then(output => {
+          expect(output.warnings).is.empty;
 
+          const expectedErrors = [
+            ERROR_HEADER,
+            `  - ${attribute} for /data/summary/details contains [/data/summary/invalid]`
+          ];
+          expect(output.errors).to.deep.equal(expectedErrors);
+        });
+    });
+  });
+
+  [
+    '/data',
+    '/data/name',
+    '../summary_title',
+    '../../name',
+    '../../address/street-nbr',
+    '../../address/../../data',
+    `concat(/data/name, 'ebmarah', ../../name)`,
+    '0 and explode(/data) + explode(explode(explode(1, 2, 3, explode(), ../../name)))',
+    `format-date-time(
+      if(selected(../summary_title, 'method_lmp'), ../../address/street-nbr,
+      if(selected(../summary_title, 'approx_weeks'), date-time(floor(decimal-date-time(today())) - (../../address/street-nbr * 7)),
+      if(selected(../summary_title, 'approx_months'), date-time(floor(decimal-date-time(today())) - round(../../address/street-nbr * 30.5)),
+      if(selected(/data/summary/summary_title, 'method_edd'), date-time(decimal-date-time(/data/name) - 280), '')
+      ))), &quot;%Y-%m-%d&quot;)`
+  ].forEach(xpath => {
+    it(`resolves OK for valid XPath(s) [${xpath}]`, () => {
+      const fields = [{ name: '/data/summary/details', type: 'string', calculate: xpath }];
+      return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
+        .then(output => assertEmpty(output));
+    });
+  });
+
+  [
+    `'coalesce(self::*, '../summary_title')'`,
+    'child::*/attribute::*',
+    'bookstore/*/title',
+    'book/*/last-name',
+    '*/*',
+    '@*',
+    '@my:*',
+    'my:*',
+    '/model/instance[1]/*//*[@template] | /model/instance[1]/*//*[@jr:template]',
+    `/bk:books/bk:book[@name = 'Harry Potter and the Half-Blood Prince']/hp:characters`,
+    '/bk:book/hp:characters',
+    `/model/instance[1]/nested_repeats/kids/has_kids='2'`,
+    '/data/p[2] * /data/p[3]',
+    'ancestor-or-self::* /ancestor-or-self::*',
+    'author',
+    'first.name',
+    '//author',
+    'author/first-name',
+    'bookstore//title',
+    'bookstore//book/excerpt//emph',
+    './/title',
+    '@style',
+    'price/@exchange',
+  ].forEach(xpath => {
+    it(`resolves OK for invalid complex XPath(s) [${xpath}]`, () => {
+      const fields = [{ name: '/data/summary/details', type: 'string', calculate: xpath }];
+      return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
+        .then(output => assertEmpty(output));
+    });
+  });
+
+  [
+    { expression: '/invalid', invalidXPaths: ['/invalid'] },
+    { expression: '/data/invalid', invalidXPaths: ['/data/invalid'] },
+    { expression: '../invalid', invalidXPaths: ['../invalid'] },
+    { expression: '../../invalid', invalidXPaths: ['../../invalid'] },
+    { expression: '../../address/invalid', invalidXPaths: ['../../address/invalid'] },
+    { expression: '../../address/../../invalid', invalidXPaths: ['../../address/../../invalid'] },
+    {
+      expression: `concat(/data/invalid, ../summary_title, ../../invalid)`,
+      invalidXPaths: ['/data/invalid', '../../invalid']
+    },
+    {
+      expression: '0 and explode(/data) + explode(explode(explode(1, /invalid, 3, explode(), ../../name)))',
+      invalidXPaths: ['/invalid']
+    },
+    {
+      expression: `format-date-time(
+          if(selected(../invalid, 'method_lmp'), ../../address/street-nbr,
+          if(selected(../invalid, 'approx_weeks'), date-time(floor(decimal-date-time(today())) - (../../address/street-nbr * 7)),
+          if(selected(../invalid, 'approx_months'), date-time(floor(decimal-date-time(today())) - round(../../address/street-nbr * 30.5)),
+          if(selected(/data/summary/invalid, 'method_edd'), date-time(decimal-date-time(/data/name) - 280), '')
+          ))), &quot;%Y-%m-%d&quot;)`,
+      invalidXPaths: ['../invalid', '../invalid', '../invalid', '/data/summary/invalid']
+    },
+  ].forEach(({ expression, invalidXPaths }) => {
+    it(`returns error(s) for invalid simple XPath(s) [${expression}]`, () => {
+      const fields = [{ name: '/data/summary/details', type: 'string', calculate: expression }];
+      return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
+        .then(output => {
+          expect(output.warnings).is.empty;
+          const expectedErrors = [ERROR_HEADER, `  - calculate for /data/summary/details contains [${invalidXPaths.join(', ')}]`];
+          expect(output.errors).to.deep.equal(expectedErrors);
+        });
+    });
+  });
+
+  it(`returns errors for invalid simple XPaths on multiple fields`, () => {
+    const fields = [
+      {
+        name: '/data/summary/details',
+        type: 'string',
+        calculate: `concat(/data/invalid, ../summary_title, ../../invalid)`
+      },
+      {
+        name: '/data/summary/summary_title',
+        type: 'string',
+        calculate: '/calculate/name',
+        constraint: '/constraint/name',
+        readonly: '/readonly/name',
+        relevant: '/relevant/name',
+        required: '/required/name',
+      },
+      {
+        name: '/data/age',
+        type: 'string',
+        calculate: '/data',
+        constraint: '/data/name',
+        readonly: 'concat(/data/readonly, ../readonly, ../../readonly)',
+        relevant: '/data/summary',
+        required: 'concat(/data/required, ../required, ../../required)',
+      },
+    ];
+    return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
+      .then(output => {
+        expect(output.warnings).is.empty;
+        const expectedErrors = [
+          ERROR_HEADER,
+          `  - calculate for /data/summary/details contains [/data/invalid, ../../invalid]`,
+          `  - calculate for /data/summary/summary_title contains [/calculate/name]`,
+          `  - constraint for /data/summary/summary_title contains [/constraint/name]`,
+          `  - readonly for /data/summary/summary_title contains [/readonly/name]`,
+          `  - relevant for /data/summary/summary_title contains [/relevant/name]`,
+          `  - required for /data/summary/summary_title contains [/required/name]`,
+          `  - readonly for /data/age contains [/data/readonly, ../readonly, ../../readonly]`,
+          `  - required for /data/age contains [/data/required, ../required, ../../required]`,
+        ];
+        expect(output.errors).to.deep.equal(expectedErrors);
+      });
+  });
+
+  it(`resolves OK for empty bind attributes`, () => {
+    const fields = [{
+      name: '/data/age',
+      type: 'string',
+      calculate: ' ',
+      constraint: '  ',
+      readonly: '   ',
+      relevant: '     ',
+      required: '      ',
+    }];
+    return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
+      .then(output => assertEmpty(output));
+  });
+
+  it(`returns an error for a form without an instance`, () => {
+    return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc([], 'not-instance') })
+      .then(output => {
+        expect(output.warnings).is.empty;
+        const expectedErrors = [`Error encountered while validating XPaths in form at ${xformPath}: No instance found in form XML.`];
+        expect(output.errors).to.deep.equal(expectedErrors);
+      });
+  });
+
+  it(`returns an error for a bind node with a nodeset that does not exist in the model`, () => {
+    const fields = [{ name: '/data/summary/invalid', type: 'string', calculate: '../../name' }];
+    return checkXPathsExist.execute({ xformPath, xmlDoc: getXmlDoc(fields) })
+      .then(output => {
+        expect(output.warnings).is.empty;
+        const expectedErrors = [`EError encountered while validating XPaths in form at ${xformPath}: Could not find model node referenced by bind nodeset: /data/summary/invalid`];
+        expect(output.errors).to.deep.equal(expectedErrors);
+      });
   });
 });
-
-// TODO include test where calculate/etc exist  but are empty

--- a/test/lib/validation/form/has-instance-id.spec.js
+++ b/test/lib/validation/form/has-instance-id.spec.js
@@ -1,9 +1,11 @@
 const { expect } = require('chai');
+const { DOMParser } = require('@xmldom/xmldom');
 
 const hasInstanceId = require('../../../../src/lib/validation/form/has-instance-id');
+const domParser = new DOMParser();
 
 const xformPath = '/my/form/path/form.xml';
-const getXml = (metaNodes = '') => `
+const getXmlDoc = (metaNodes = '') => domParser.parseFromString(`
 <?xml version="1.0"?>
 <h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <h:head>
@@ -25,11 +27,11 @@ const getXml = (metaNodes = '') => `
       <label>What is the name?</label>
     </input>
   </h:body>
-</h:html>`;
+</h:html>`);
 
 describe('has-instance-id', () => {
   it('should resolve OK when form has instance id', () => {
-    return hasInstanceId.execute({ xformPath, xmlStr: getXml('<instanceID/>') })
+    return hasInstanceId.execute({ xformPath, xmlDoc: getXmlDoc('<instanceID/>') })
       .then(output => {
         expect(output.warnings).is.empty;
         expect(output.errors).is.empty;
@@ -37,7 +39,7 @@ describe('has-instance-id', () => {
   });
 
   it('should return error when form does not have an instance id', () => {
-    return hasInstanceId.execute({ xformPath, xmlStr: getXml() })
+    return hasInstanceId.execute({ xformPath, xmlDoc: getXmlDoc() })
       .then(output => {
         expect(output.warnings).is.empty;
         expect(output.errors).deep


### PR DESCRIPTION
# Description

Adds support for validating simple XPath expressions in form XML files.  Simple XPaths, (ones that only describe a full path (either absolute or relative) to a node) in forms should always refer to a node that actually exists in the form (otherwise they would never actually result in a value).  XPaths that fail this check are almost certainly a bug.  

More complex XPath's (that might have conditional logic that depends on the actual data in the form) are not evaluated.

Note that I have only been able to find one "false positive" case (where an error is flagged when it should not be).  This case requires the XPath expression to include:

- Multiple string literals that are quoted using different quotes (single quotes vs double quotes)
  - (note that XPath does not support escape characters so if one string literal _contains_ a quote character (single or double) then the string literal, itself, must be created with the other type of quote.)
- The former string literal contains a value that technically is an invalid simple XPath expression (but should not be flagged as an error since it is in a string).
- A latter string literal _contains_ a single (or odd number) quote character (either single quote or double quote) that is the same type of quote as the characters used to quote the string literal containing the XPath expression

For example, `concat('/Users/joe/Desktop/myfile.txt', &quot;Joe's File&quot;)` will cause the validation to fail saying that `/Users/joe/Desktop/myFile.txt` is an invalid XPath expression because the quote in "Joe's" confuses the regex into thinking that `'/Users/joe/Desktop/myfile.txt'` is not actually in a string literal.  This seems like a pretty extreme edge case and not one that I am terribly worried about hitting. However, if any forms do run into this, it is worth noting that it can easily be fixed by updating the string literal containing the simple XPath to just use the other type of quote: `concat(&quot;/Users/joe/Desktop/myfile.txt&quot;, &quot;Joe's File&quot;)`.

Closes #479 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
