### PR TITLE
chore(#497): Add additional cleanup for the watch-project tests

### DIFF
--- a/test/fn/watch-project.spec.js
+++ b/test/fn/watch-project.spec.js
@@ -20,10 +20,14 @@ const testDir = path.join(__dirname, '../data/skeleton');
 const appFormDir = path.join(testDir, APP_FORMS_PATH);
 const collectFormsDir = path.join(testDir, COLLECT_FORMS_PATH);
 const contactFormsDir = path.join(testDir, CONTACT_FORMS_PATH);
-const settingsPath = path.join(testDir, APP_SETTINGS_DIR_PATH, 'base_settings.json');
+const snapshotsDir = path.join(testDir, '.snapshots');
+const baseSettingsPath = path.join(testDir, APP_SETTINGS_DIR_PATH, 'base_settings.json');
+const appSettingsPath = path.join(testDir, 'app_settings.json');
 const sampleTranslationPath = path.join(testDir, 'translations', 'messages-en.properties');
 const resourceJsonPath = path.join(testDir, RESOURCE_CONFIG_PATH);
-const appSettings = fs.readJson(settingsPath);
+const baseSettings = fs.readJson(baseSettingsPath);
+const appSettings = fs.readJson(appSettingsPath);
+const messagesEn = fs.read(sampleTranslationPath);
 
 const mockApi = {
   updateAppSettings: (content) => {
@@ -36,15 +40,15 @@ const mockApi = {
 };
 
 function editBaseSettings() {
-  const appSettings = fs.readJson(settingsPath);
+  const appSettings = fs.readJson(baseSettingsPath);
   appSettings.locale = 'es';
-  fs.writeJson(settingsPath, appSettings);
+  fs.writeJson(baseSettingsPath, appSettings);
 }
 
 function editAppSettings() {
-  const appSettings = fs.readJson(path.join(testDir, 'app_settings.json'));
+  const appSettings = fs.readJson(appSettingsPath);
   appSettings.locale = 'es';
-  fs.writeJson(path.join(testDir, 'app_settings.json'), appSettings);
+  fs.writeJson(appSettingsPath, appSettings);
 }
 
 function editTranslations() {
@@ -94,7 +98,13 @@ describe('watch-project', function () {
 
   afterEach(() => {
     sinon.restore();
-    fs.writeJson(settingsPath, appSettings);
+    fs.writeJson(baseSettingsPath, baseSettings);
+    fs.writeJson(appSettingsPath, appSettings);
+    fs.write(sampleTranslationPath, messagesEn);
+    if(fs.exists(snapshotsDir)) {
+      fs.deleteFilesInFolder(snapshotsDir);
+      fs.fs.rmdirSync(snapshotsDir);
+    }
     watchProject.close();
     return api.stop();
   });


### PR DESCRIPTION
# Description

Currently, after running `npm test` on a freshly checked out version of `cht-conf`, you will notice that there are several uncommitted changes in the repo directory.  Basically, the https://github.com/medic/cht-conf/blob/main/test/fn/watch-project.spec.js tests end up adding/modifying several files that are not cleaned up when the test finishes:

```.sh
❯ git status
On branch main
Your branch is up to date with 'origin/main'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   test/data/skeleton/app_settings.json
        modified:   test/data/skeleton/translations/messages-en.properties

Untracked files:
  (use "git add <file>..." to include in what will be committed)
        test/data/skeleton/.snapshots/
```

The goal of this PR is just to update the test file to clean up these changes after the tests.

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
