### PR TITLE
Uplift GitHub workflows to run on ubuntu-22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build for Node version ${{ matrix.node-version }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build for Node version ${{ matrix.node-version }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -18,10 +18,10 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Setting up python 2.X
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v2
       with:
-        python-version: '2.7.18'
-#        architecture: 'x64'
+        python-version: '2.x'
+        architecture: 'x64'
     - name: Installing wheel package for pip # This makes the warning about legacy installing go away.
       uses: BSFishy/pip-action@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build for Node version ${{ matrix.node-version }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04 # 22.04 does not support Python 2.x
 
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: '2.7.18'
-        architecture: 'x64'
+#        architecture: 'x64'
     - name: Installing wheel package for pip # This makes the warning about legacy installing go away.
       uses: BSFishy/pip-action@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
     - name: Setting up python 2.X
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '2.7.18'
         architecture: 'x64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setting up python 2.X
       uses: actions/setup-python@v2
       with:
-        python-version: '2.x'
+        python-version: '2.7.18'
         architecture: 'x64'
     - name: Installing wheel package for pip # This makes the warning about legacy installing go away.
       uses: BSFishy/pip-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
# Description

Updates the GitHub workflows so that they run on the latest `ubuntu-22.04` image.  Note that the `build` workflow could not actually be updated to 22.04 since it depends on Python 2. So, I have pinned it at 20.22 and listed this as something that should be changed when we [uplift our base Python version](https://github.com/medic/cht-core/issues/6537).

https://github.com/medic/cht-core/issues/7741

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
