### PR TITLE
saving tge current form before replacing it

### DIFF
--- a/src/lib/save-current-form-to-old-form.js
+++ b/src/lib/save-current-form-to-old-form.js
@@ -1,0 +1,26 @@
+const {info} = require('./log');
+module.exports = (db, doc) =>
+    db.get(doc._id, { attachments: true, binary: true })
+        .then(existingDoc => {
+            existingDoc.doc_id = existingDoc._id;
+            existingDoc.type = 'old-form';
+            existingDoc._id = undefined;
+            existingDoc._rev = undefined;
+            const attachments = existingDoc._attachments;
+            existingDoc._attachments = {};
+            Object.keys(attachments).forEach(name => {
+                existingDoc._attachments[name] = {};
+                const keys = Object.keys(attachments[name]);
+                if (keys.includes('content_type') && keys.includes('data')) {
+                    existingDoc._attachments[name]['content_type'] = attachments[name]['content_type'];
+                    existingDoc._attachments[name]['data'] = Buffer.from(attachments[name]['data']);
+                }
+            });
+            return db.post(existingDoc);
+        })
+        .then(response => info(`previous form saved in doc with _id: ${response.id} type:'old-form'`))
+        .catch(e => {
+            info('old form failed');
+            if(e.status === 404) return;
+            else throw e;
+        });

--- a/src/lib/upload-forms.js
+++ b/src/lib/upload-forms.js
@@ -5,6 +5,7 @@ const crypto = require('crypto');
 const fs = require('./sync-fs');
 const log = require('./log');
 const insertOrReplace = require('./insert-or-replace');
+const saveCurrentFormToOldForm = require('./save-current-form-to-old-form')
 const pouch = require('./db');
 const warnUploadOverwrite = require('./warn-upload-overwrite');
 const {
@@ -90,6 +91,7 @@ const execute = async (projectDir, subDirectory, options) => {
 
     const changes = await warnUploadOverwrite.preUploadForm(db, doc, xml, properties);
     if (changes) {
+      await saveCurrentFormToOldForm(db, doc);
       await insertOrReplace(db, doc);
       log.info(`Form ${filePath} uploaded`);
     } else {


### PR DESCRIPTION
This is related to [https://github.com/medic/cht-conf/issues/505](https://github.com/medic/cht-conf/issues/505)

Is your feature request related to a problem? Please describe.
the cht-conf version 10 add the xml_version json key to the form doc when the action upload-app-forms is executed, but the new form of a given form._id replaces the old one and the old xml file is overwritten.
The cht add the form version of the form doc to its data_records.
If a data analyst found a trouble with a current form, he can always learn about collected data using the form, but if the problem is with historical old data, he knows fields sent into the data_record but he is not able to investigate data collection processus and for example, learn about how such a value is possible in a variable;

Describe the solution you'd like
We propose that upload-app-forms does not replace old version but :

before to the replacing, the old form is copied to a new doc but with type: "old-form" and the _id of replaced form is stored in the doc with type "old-form" using the key "doc-id";=:"form:formId", attachements, xml, form_html and model are saved to this type:"old-form" new doc
the form is replaced as now
Additional context
some endpoints could be added to the cht-core forms API to retrieve all versions of a given form:formID; and to get the xml file of a given form version something like GET api/v1/forms/{formid}.{format]/{sha1}
