### PR TITLE
Target date default to Now #7711

### DIFF
--- a/src/nools/target-emitter.js
+++ b/src/nools/target-emitter.js
@@ -23,10 +23,10 @@ function targetEmitter(targets, c, Utils, Target, emit) {
 
 function determineDate(targetConfig, Utils, c, r) {
   if (typeof targetConfig.date === 'function') {
-    return targetConfig.date(c, r);
+    return targetConfig.date(c, r) || Utils.now().getTime();
   }
 
-  if (targetConfig.date === undefined || targetConfig.date === 'now') {
+  if (targetConfig.date === undefined || targetConfig.date === null || targetConfig.date === 'now') {
     return Utils.now().getTime();
   }
 

--- a/test/nools/target-emitter.spec.js
+++ b/test/nools/target-emitter.spec.js
@@ -149,6 +149,27 @@ describe('target emitter', () => {
         ]);
       });
 
+      it('should default to "now" if target date is a function returning null', () => {
+        // given
+        const target = aPersonBasedTarget();
+        target.date = () => null ;
+        // and
+        const config = {
+          c: personWithoutReports(),
+          targets: [ target ],
+          tasks: [],
+        };
+
+        // when
+        const emitted = runNoolsLib(config).emitted;
+
+        // then
+        assert.deepEqual(emitted, [
+          { _id: 'c-2~pT-1', _type:'target', date:TEST_DATE },
+          { _type:'_complete', _id: true },
+        ]);
+      });
+
       it('should not emit if appliesToType doesnt match', () => {
         // given
         const target = aPersonBasedTarget();

--- a/test/nools/target-emitter.spec.js
+++ b/test/nools/target-emitter.spec.js
@@ -165,8 +165,8 @@ describe('target emitter', () => {
 
         // then
         assert.deepEqual(emitted, [
-          { _id: 'c-2~pT-1', _type:'target', date:TEST_DATE },
-          { _type:'_complete', _id: true },
+          { _id: 'c-2~pT-1', _type: 'target', date: TEST_DATE },
+          { _type: '_complete', _id: true },
         ]);
       });
 


### PR DESCRIPTION
# Description

This PR changes the target emitter to default to now when the config target date is null or is a function that returns null.

medic/cht-conf#516

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
