### PR TITLE
fix(#504): escape whitespaces in path when converting forms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ upload-docs.*.log.json
 *.swp
 coverage
 .nyc_output
+.DS_Store
+test/.DS_Store

--- a/src/lib/convert-forms.js
+++ b/src/lib/convert-forms.js
@@ -3,8 +3,7 @@ const { execSync } = require('child_process');
 const argsFormFilter = require('./args-form-filter');
 const exec = require('./exec-promise');
 const fs = require('./sync-fs');
-const { getFormDir } = require('./forms-utils');
-const { escapeWhitespacesInPath } = require('./forms-utils');
+const { getFormDir, escapeWhitespacesInPath } = require('./forms-utils');
 const { info, trace, warn } = require('./log');
 
 const XLS2XFORM = 'xls2xform-medic';

--- a/src/lib/convert-forms.js
+++ b/src/lib/convert-forms.js
@@ -4,6 +4,7 @@ const argsFormFilter = require('./args-form-filter');
 const exec = require('./exec-promise');
 const fs = require('./sync-fs');
 const { getFormDir } = require('./forms-utils');
+const { escapeWhitespacesInPath } = require('./forms-utils');
 const { info, trace, warn } = require('./log');
 
 const XLS2XFORM = 'xls2xform-medic';
@@ -56,7 +57,8 @@ const execute = async (projectDir, subDirectory, options) => {
     const targetPath = `${fs.withoutExtension(originalSourcePath)}.xml`;
 
     info('Converting form', originalSourcePath, '…');
-    await xls2xform(sourcePath, targetPath);
+  
+    await xls2xform(escapeWhitespacesInPath(sourcePath), escapeWhitespacesInPath(targetPath));
     const hiddenFields = await getHiddenFields(`${fs.withoutExtension(originalSourcePath)}.properties.json`);
     await fixXml(targetPath, hiddenFields, options.transformer, options.enketo);
     trace('Converted form', originalSourcePath);

--- a/src/lib/forms-utils.js
+++ b/src/lib/forms-utils.js
@@ -95,4 +95,12 @@ module.exports = {
     xml.match(/<model>[^]*<\/model>/)[0]
       .match(/<instance>[^]*<\/instance>/)[0]
       .match(/id="([^"]*)"/)[1],
+
+  /**
+   * Escape whitespaces in a path.
+   * @param {string} path the path string
+   * @returns {string}
+   */
+  escapeWhitespacesInPath: path => path.replace(/(\s+)/g, '\\$1'),
+  
 };

--- a/test/lib/convert-forms.spec.js
+++ b/test/lib/convert-forms.spec.js
@@ -44,5 +44,11 @@ describe('convert-forms', () => {
       await convertForms.execute('./path', 'app', { forms: ['--debug'] });
       expect(mockXls2xform.callCount).to.eq(2);
     }));
+
+    it('escape whitespaces in path and convert forms', () => withMocks(async () => {
+      await convertForms.execute('./path with space', 'app');
+      expect(mockXls2xform.callCount).to.eq(2);
+      expect(mockXls2xform.args[0]).to.deep.eq(['./path\\ with\\ space/forms/app/b.xlsx', './path\\ with\\ space/forms/app/b.xml']);
+    }));
   });
 });


### PR DESCRIPTION
# Description

Escapes whitespaces in path before converting forms.

Closes #504 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
