### PR TITLE
Fix CI configuration so docker image gets deployed

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -1,0 +1,17 @@
+name: "Lint PR"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -14,7 +14,7 @@
       "@semantic-release/git",
       {
         "assets": ["package.json", "package-lock.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]"
+        "message": "chore(release): ${nextRelease.version}"
       }
     ]
   ],


### PR DESCRIPTION
# Description

Currently the `publish_docker_image` workflow is not getting triggered by tags created by `semantic-release` because the commits from `semantic-release` include "[skip-ci]". Removing this from the commit messages should allow the docker image workflow to be properly triggered for new releases.

As a further enhancement to our release process, I would like to propose we include the [`action-semantic-pull-request` action](https://github.com/amannn/action-semantic-pull-request) that can lint our PR titles to make sure they have the proper format required by `semantic-release`.  Since we can set the PR title as the _default commit message_ when squash-merging the PR, this would help to ensure that the commits merged to `main` actually have the proper message format.  (After quite a bit of digging, I have not been able to find any other way to actually set a default PR title or lint/verify the commit message before merging the PR....)

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
