### PR TITLE
Fix #555 for non-existing directory

### DIFF
--- a/src/fn/upload-extension-libs.js
+++ b/src/fn/upload-extension-libs.js
@@ -14,7 +14,7 @@ module.exports = {
     const configurationDir = `${environment.pathToProject}/${projectPaths.EXTENSION_LIBS_PATH}`;
 
     const attachments = attachmentsFromDir(configurationDir);
-    if (!Object.keys(attachments).length) {
+    if (!attachments || !Object.keys(attachments).length) {
       log.info(`No configuration found at "${configurationDir}" - not uploading extension-libs`);
       return;
     }

--- a/test/fn/upload-extension-libs.spec.js
+++ b/test/fn/upload-extension-libs.spec.js
@@ -41,6 +41,15 @@ describe('Upload extension libs', () => {
     expect(log.info.args[0][0]).to.equal('No configuration found at "/testpath/extension-libs" - not uploading extension-libs');
   });
 
+  it('log and skip when dir does not exist', async () => {
+    attachmentsFromDir.returns(undefined);
+    await uploadExtensionLibs.execute();
+    expect(attachmentsFromDir.callCount).to.equal(1);
+    expect(insertOrReplace.callCount).to.equal(0);
+    expect(log.info.callCount).to.equal(1);
+    expect(log.info.args[0][0]).to.equal('No configuration found at "/testpath/extension-libs" - not uploading extension-libs');
+  });
+
   it('does nothing if doc matches remote', async () => {
     attachmentsFromDir.returns({ 'script.js': {}, 'data.json': {} });
     warnUploadOverwrite.preUploadDoc.resolves(false);


### PR DESCRIPTION
# Description

Fixes
medic/cht-conf#555

Ensure that upload-extension-libs doesn't throw an error when `extension-libs` folder doesn't exist. The action warns and continues. 

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
