### PR TITLE
fix(#554): update docker creds used to push cht-app-ide image

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -5,7 +5,6 @@ on:
     tags: ['v*']
 
 env:
-  DOCKER_HUB_USER: dockermedic
   DOCKER_NAMESPACE: medicmobile
   DOCKER_REPOSITORY: cht-app-ide
 
@@ -20,8 +19,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ env.DOCKER_HUB_USER }}
-          password: ${{ secrets.DOCKER_HUB_PASS }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
The saga continues....  I used the Docker admin account from 1Password to create https://hub.docker.com/r/medicmobile/cht-app-ide as a public repo. Unfortunately, it seems like the `dockermedic` account does not have permissions to push to `medicmobile` (it also did not have permissions to create a new repo in that org).  I tried locally using `medicmobile` to push an image and got the same `denied: requested access to the resource is denied` error that [we are seeing in the CI](https://github.com/medic/cht-conf/actions/runs/4791367443/jobs/8560319565).

Since the [openmin-mediator workflow](https://github.com/medic/cht-interoperability/blob/main/.github/workflows/docker-build.yml) can successfully push images with the creds configured in `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` I am going to just switch to using those (maybe should have done that in the first place???).  

https://github.com/medic/cht-conf/issues/554

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
