### PR TITLE
Revert "fix(#554): update docker creds used to push cht-app-ide image(#558)"

### DIFF
--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -5,6 +5,7 @@ on:
     tags: ['v*']
 
 env:
+  DOCKER_HUB_USER: dockermedic
   DOCKER_NAMESPACE: medicmobile
   DOCKER_REPOSITORY: cht-app-ide
 
@@ -19,8 +20,8 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKER_HUB_USER }}
+          password: ${{ secrets.DOCKER_HUB_PASS }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta


### PR DESCRIPTION
Attempt #6 to publish cht-app-ide Docker image.... :facepalm: 

Based on [this conversation](https://medic.slack.com/archives/C024KTGRW/p1682608750337879), the [change](https://github.com/medic/cht-conf/pull/558) to use `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` was wrong because those were repo-level variables.  `dockermedic`/`DOCKER_HUB_PASS` _should_ work but I think the issue was that I needed to grant permissions on the `cht-app-ide` Docker Hub repo level for the `dockermedic` user to be able to push images.  Those permissions have been added and now we should be able to push images with the original configuration....

https://github.com/medic/cht-conf/issues/554

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
