### PR TITLE
chore(#562): use default Python3 for GitHub action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Install wheel
-      run: pip install wheel
     - name: Install pyxform
       run: pip install git+https://github.com/medic/pyxform.git@medic-conf-1.17#egg=pyxform-medic
     - name: npm ci and test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
     name: Build for Node version ${{ matrix.node-version }}
-    runs-on: ubuntu-20.04 # 22.04 does not support Python 2.x
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -18,11 +18,6 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-    - name: Setting up python 2.X
-      uses: actions/setup-python@v4
-      with:
-        python-version: '2.x'
-        architecture: 'x64'
     - name: Install wheel
       run: pip install wheel
     - name: Install pyxform


### PR DESCRIPTION
# Description

Closes https://github.com/medic/cht-conf/issues/562

Python 2.x is [no longer supported](https://github.com/actions/setup-python/issues/672) by the official `setup-python` GitHub Action.  However, I do not believe there is anything stopping us from just building cht-conf with Python3 (installed by default on the `ubuntu` image).  

This PR just removes the `setup-python` config for the GetHub action and allows the build to run with the default Python3 (the same as the [cht-core GitHub action](https://github.com/medic/cht-core/blob/ba3b0c437b3b9105c0a523edf5d497a2a1a885ad/.github/workflows/build.yml#L149) (Additionally, I have removed the step for installing `wheel` since that is already included for python3 on the `ubuntu` image.)

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
