### PR TITLE
feat(#578): accept array for start_from

### DIFF
--- a/src/lib/validate-app-settings.js
+++ b/src/lib/validate-app-settings.js
@@ -42,7 +42,7 @@ const ScheduleSchema = joi.array().items(
     name: joi.string().required(),
     summary: joi.string().allow(''),
     description: joi.string().allow(''),
-    start_from: joi.string(),
+    start_from: joi.alternatives().try(joi.string(), joi.array()),
     start_mid_group: joi.boolean(),
     translation_key: joi.string(),
     messages: joi.array().items(

--- a/test/lib/validate-app-settings.spec.js
+++ b/test/lib/validate-app-settings.spec.js
@@ -30,7 +30,7 @@ describe('validate-app-settings', () => {
             patient_id: {
               position: 0,
               flags: { input_digits_only: true },
-              length: [ 5, 13 ],
+              length: [5, 13],
               type: 'string',
               required: true
             }
@@ -80,6 +80,68 @@ describe('validate-app-settings', () => {
           }
         }
       }, '"DR.meta" is required');
+    });
+
+  });
+
+  describe('validateSchedulesSchema', () => {
+    const isValid = (schedulesObject) => {
+      const result = validateAppSettings.validateScheduleSchema(schedulesObject);
+      expect(result.valid).to.be.true;
+    };
+
+    const isNotValid = (schedulesObject, errorMessage) => {
+      const result = validateAppSettings.validateScheduleSchema(schedulesObject);
+      expect(result.valid).to.be.false;
+      expect(result.error.details.length).to.equal(1);
+      expect(result.error.details[0].message).to.equal(errorMessage);
+    };
+
+    it('returns valid for starter schedule.', () => {
+      isValid([{
+        name: 'schedule name',
+        messages: [{
+          translation_key: 'a.b',
+          group: '1',
+          offset: '0'
+        }]
+      }]);
+    });
+
+    it('start_from as string is valid.', () => {
+      isValid([{
+        name: 'schedule name',
+        start_from: 'dob',
+        messages: [{
+          translation_key: 'a.b',
+          group: '1',
+          offset: '0'
+        }]
+      }]);
+    });
+
+    it('start_from as an array is valid.', () => {
+      isValid([{
+        name: 'schedule name',
+        start_from: ['dob', 'lmp_date'],
+        messages: [{
+          translation_key: 'a.b',
+          group: '1',
+          offset: '0'
+        }]
+      }]);
+    });
+
+    it('start_from as a number is invalid.', () => {
+      isNotValid([{
+        name: 'schedule name',
+        start_from: 1,
+        messages: [{
+          translation_key: 'a.b',
+          group: '1',
+          offset: '0'
+        }]
+      }], '"[0].start_from" must be one of [string, array]');
     });
 
   });


### PR DESCRIPTION
# Description
Accept dates on start_from
medic/cht-conf#578

Related to medic/cht-core#8633

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
