### PR TITLE
feat(#575): retry failed HTTP requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@medic/translation-checker": "^1.0.1",
         "@parcel/watcher": "^2.0.5",
         "@xmldom/xmldom": "^0.8.10",
+        "async-retry": "^1.3.3",
         "canonical-json": "0.0.4",
         "csv-parse": "^4.16.0",
         "dom-compare": "^0.6.0",
@@ -2812,6 +2813,14 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "optional": true
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -17027,7 +17036,6 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -22808,6 +22816,14 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
       "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
       "optional": true
+    },
+    "async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "requires": {
+        "retry": "0.13.1"
+      }
     },
     "asynckit": {
       "version": "0.4.0",
@@ -33981,8 +33997,7 @@
     "retry": {
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "dev": true
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@medic/translation-checker": "^1.0.1",
     "@parcel/watcher": "^2.0.5",
     "@xmldom/xmldom": "^0.8.10",
+    "async-retry": "^1.3.3",
     "canonical-json": "0.0.4",
     "csv-parse": "^4.16.0",
     "dom-compare": "^0.6.0",

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -11,12 +11,8 @@ const cache = new Map();
 const _request = (method) => (...args) => retry(() => rpn[method](...args), { retries: 0 });
 const request = {
   get: _request('get'),
-  head: _request('head'),
-  options: _request('options'),
   post: _request('post'),
   put: _request('put'),
-  patch: _request('patch'),
-  delete: _request('delete'),
 };
 
 const logDeprecatedTransitions = (settings) => {

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -103,7 +103,6 @@ const api = {
     try {
       await request.get(url);
     } catch (err) {
-      console.log('err', err);
       if (err.statusCode === 401) {
         throw new Error(`Authentication failed connecting to ${url}. `
           + 'Check the supplied username and password and try again.');

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -8,7 +8,7 @@ const url = require('url');
 
 const cache = new Map();
 
-const _request = (method) => (...args) => retry(() => rpn[method](...args), { retries: 0 });
+const _request = (method) => (...args) => retry(() => rpn[method](...args), { retries: 5, randomize: false, factor: 1.5 });
 const request = {
   get: _request('get'),
   post: _request('post'),

--- a/test/fn/create-users.spec.js
+++ b/test/fn/create-users.spec.js
@@ -316,6 +316,11 @@ describe('create-users', function () {
     const pwd = 'Secret_1';
     api.giveResponses(
       { status: 400, body: { code: 400, error: 'not an offline role' } },
+      { status: 400, body: { code: 400, error: 'not an offline role' } },
+      { status: 400, body: { code: 400, error: 'not an offline role' } },
+      { status: 400, body: { code: 400, error: 'not an offline role' } },
+      { status: 400, body: { code: 400, error: 'not an offline role' } },
+      { status: 400, body: { code: 400, error: 'not an offline role' } },
       { body: { total_docs: 12000, warn: true, limit: 10000 } },
       { body: { total_docs: 10200, warn: true, limit: 10000 } },
       { body: { total_docs: 1000, warn: false, limit: 10000 } },
@@ -335,6 +340,11 @@ describe('create-users', function () {
       .catch(() => {
         assert.equal(readLine.keyInYN.callCount, 1);
         assert.deepEqual(api.requestLog(), [
+          { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
           { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
           { method: 'GET', url: '/api/v1/users-info?' + qs(jack), body: {} },
           { method: 'GET', url: '/api/v1/users-info?' + qs(jill), body: {} },

--- a/test/fn/create-users.spec.js
+++ b/test/fn/create-users.spec.js
@@ -263,10 +263,16 @@ describe('create-users', function () {
       });
   });
 
-  it('should request user-info in sequence before creating users', () => {
+  it('should request user-info in sequence before creating users', function () {
+    this.timeout(30000);
     mockTestDir(`data/create-users/multiple-existing-place`);
     const pwd = 'Secret_1';
     api.giveResponses(
+      { status: 400, body: { code: 400, error: 'not an offline role' } },
+      { status: 400, body: { code: 400, error: 'not an offline role' } },
+      { status: 400, body: { code: 400, error: 'not an offline role' } },
+      { status: 400, body: { code: 400, error: 'not an offline role' } },
+      { status: 400, body: { code: 400, error: 'not an offline role' } },
       { status: 400, body: { code: 400, error: 'not an offline role' } },
       { body: { total_docs: 12000, warn: true, limit: 10000 } },
       { body: { total_docs: 10200, warn: true, limit: 10000 } },
@@ -288,6 +294,11 @@ describe('create-users', function () {
       .then(() => {
         assert.equal(readLine.keyInYN.callCount, 1);
         assert.deepEqual(api.requestLog(), [
+          { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
           { method: 'GET', url: '/api/v1/users-info?' + qs(todd), body: {} },
           { method: 'GET', url: '/api/v1/users-info?' + qs(jack), body: {} },
           { method: 'GET', url: '/api/v1/users-info?' + qs(jill), body: {} },

--- a/test/fn/create-users.spec.js
+++ b/test/fn/create-users.spec.js
@@ -12,7 +12,9 @@ const userPrompt = rewire('../../src/lib/user-prompt');
 const readLine = require('readline-sync');
 const mockTestDir = testDir => sinon.stub(environment, 'pathToProject').get(() => testDir);
 
-describe('create-users', () => {
+describe('create-users', function () {
+  this.timeout(15000);
+
   beforeEach(() => {
     createUsers.__set__('userPrompt', userPrompt);
     sinon.stub(environment, 'isArchiveMode').get(() => false);
@@ -86,7 +88,15 @@ describe('create-users', () => {
 
   it('should create user with existent place and not implemented user-info endpoint', () => {
     mockTestDir(`data/create-users/existing-place`);
-    api.giveResponses({ status: 404, body: { code: 404, error: 'not_found' } }, { body: {} });
+    api.giveResponses(
+      { status: 404, body: { code: 404, error: 'not_found' } },
+      { status: 404, body: { code: 404, error: 'not_found' } },
+      { status: 404, body: { code: 404, error: 'not_found' } },
+      { status: 404, body: { code: 404, error: 'not_found' } },
+      { status: 404, body: { code: 404, error: 'not_found' } },
+      { status: 404, body: { code: 404, error: 'not_found' } },
+      { body: {} },
+    );
     const todd = {
       username: 'todd',
       password: 'Secret_1',
@@ -108,6 +118,11 @@ describe('create-users', () => {
       .then(() => /* when */ createUsers.execute())
       .then(() => {
         assert.deepEqual(api.requestLog(), [
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
           { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
           { method: 'POST', url: '/api/v1/users', body: todd },
         ]);
@@ -220,7 +235,14 @@ describe('create-users', () => {
       },
     };
 
-    api.giveResponses({ status: 500, body: { code: 500, error: 'boom' } } );
+    api.giveResponses(
+        { status: 500, body: { code: 500, error: 'boom' } },
+        { status: 500, body: { code: 500, error: 'boom' } },
+        { status: 500, body: { code: 500, error: 'boom' } },
+        { status: 500, body: { code: 500, error: 'boom' } },
+        { status: 500, body: { code: 500, error: 'boom' } },
+        { status: 500, body: { code: 500, error: 'boom' } },
+    );
     const qs = {
       facility_id: todd.place,
       role: JSON.stringify(todd.roles),
@@ -231,6 +253,11 @@ describe('create-users', () => {
       .catch(err => {
         assert.deepEqual(err.error, { code: 500, error: 'boom' });
         assert.deepEqual(api.requestLog(), [
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
+          { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
           { method: 'GET', url: '/api/v1/users-info?' + querystring.stringify(qs), body: {} },
         ]);
       });

--- a/test/fn/upload-custom-translations.spec.js
+++ b/test/fn/upload-custom-translations.spec.js
@@ -398,15 +398,6 @@ describe('upload-custom-translations', function () {
       });
 
       it('should replace existent custom values', () => {
-        api.giveResponses(
-          { status: 404, body: { error: 'not_found' } },
-          { status: 404, body: { error: 'not_found' } },
-          { status: 404, body: { error: 'not_found' } },
-          { status: 404, body: { error: 'not_found' } },
-          { status: 404, body: { error: 'not_found' } },
-          { status: 404, body: { error: 'not_found' } },
-        );
-
         mockTestDir(`with-customs`);
         return api.db
           .put({
@@ -509,10 +500,6 @@ describe('upload-custom-translations', function () {
         // api/deploy-info endpoint exists
         api.giveResponses(
           { status: 200, body: { version: '3.5.0' } },
-          {
-            status: 200,
-            body: { compressible_types: 'text/*, application/javascript, application/json, application/xml' },
-          },
         );
 
         mockTestDir(`simple`);

--- a/test/fn/upload-custom-translations.spec.js
+++ b/test/fn/upload-custom-translations.spec.js
@@ -493,15 +493,12 @@ describe('upload-custom-translations', function () {
 
     describe('3.5.0', () => {
       beforeEach(() => {
+        // api/deploy-info endpoint exists
+        api.giveResponses({ status: 200, body: { version: '3.5.0' } });
         return api.db.put({ _id: '_design/medic-client', deploy_info: { version: '3.5.0' } });
       });
 
       it('should upload simple translations', () => {
-        // api/deploy-info endpoint exists
-        api.giveResponses(
-          { status: 200, body: { version: '3.5.0' } },
-        );
-
         mockTestDir(`simple`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en'))
@@ -514,15 +511,6 @@ describe('upload-custom-translations', function () {
       });
 
       it('should upload translations for multiple languages', () => {
-        // api/deploy-info endpoint exists
-        api.giveResponses(
-          { status: 200, body: { version: '3.5.0' } },
-          {
-            status: 200,
-            body: { compressible_types: 'text/*, application/javascript, application/json, application/xml' },
-          },
-        );
-
         mockTestDir(`multi-lang`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en', 'fr'))
@@ -543,9 +531,6 @@ describe('upload-custom-translations', function () {
       });
 
       it('should upload translations containing equals signs', () => {
-        // api/deploy-info endpoint exists
-        api.giveResponses({ status: 200, body: { version: '3.5.0' } });
-
         mockTestDir(`contains-equals`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en'))
@@ -561,9 +546,6 @@ describe('upload-custom-translations', function () {
       });
 
       it('should set default name for unknown language', () => {
-        // api/deploy-info endpoint exists
-        api.giveResponses({ status: 200, body: { version: '3.5.0' } });
-
         mockTestDir(`unknown-lang`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'qp'))
@@ -574,9 +556,6 @@ describe('upload-custom-translations', function () {
       });
 
       it('should properly upload translations containing escaped exclamation marks', () => {
-        // api/deploy-info endpoint exists
-        api.giveResponses({ status: 200, body: { version: '3.5.0' } });
-
         mockTestDir(`escaped-exclamation`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en'))
@@ -592,9 +571,6 @@ describe('upload-custom-translations', function () {
       });
 
       it('upload translations containing empty messages raises warn logs but works', () => {
-        // api/deploy-info endpoint exists
-        api.giveResponses({ status: 200, body: { version: '3.5.0' } });
-
         mockTestDir('contains-empty-messages');
         sinon.replace(log, 'warn', sinon.fake());
         return uploadCustomTranslations()

--- a/test/fn/upload-custom-translations.spec.js
+++ b/test/fn/upload-custom-translations.spec.js
@@ -7,9 +7,7 @@ const log = require('../../src/lib/log');
 const uploadCustomTranslations = require('../../src/fn/upload-custom-translations').execute;
 const { getTranslationDoc,  expectTranslationDocs } = require('./utils');
 
-describe('upload-custom-translations', function () {
-  this.timeout(45000);
-
+describe('upload-custom-translations', () => {
   const testProjectDir = './data/upload-custom-translations/';
   let mockTestDir;
 
@@ -27,7 +25,9 @@ describe('upload-custom-translations', function () {
     await api.stop();
   });
 
-  describe('medic-2.x', () => {
+  describe('medic-2.x', function () {
+    this.timeout(60000);
+
     beforeEach(() => {
       // medic-client does not have deploy_info property
       return api.db.put({ _id: '_design/medic-client' });
@@ -42,10 +42,6 @@ describe('upload-custom-translations', function () {
         { status: 404, body: { error: 'not_found' } },
         { status: 404, body: { error: 'not_found' } },
         { status: 404, body: { error: 'not_found' } },
-        {
-          status: 200,
-          body: { compressible_types: 'text/*, application/javascript, application/json, application/xml' },
-        },
       );
 
       mockTestDir(`simple`);
@@ -68,10 +64,6 @@ describe('upload-custom-translations', function () {
         { status: 404, body: { error: 'not_found' } },
         { status: 404, body: { error: 'not_found' } },
         { status: 404, body: { error: 'not_found' } },
-        {
-          status: 200,
-          body: { compressible_types: 'text/*, application/javascript, application/json, application/xml' },
-        },
       );
 
       mockTestDir(`multi-lang`);
@@ -178,21 +170,10 @@ describe('upload-custom-translations', function () {
   });
 
   describe('medic-3.x', () => {
-    describe('3.0.0', () => {
-      beforeEach(() => {
-        /*api.giveResponses(
-          { status: 404, body: { error: 'not_found' } },
-          { status: 404, body: { error: 'not_found' } },
-          { status: 404, body: { error: 'not_found' } },
-          { status: 404, body: { error: 'not_found' } },
-          { status: 404, body: { error: 'not_found' } },
-          { status: 404, body: { error: 'not_found' } },
-          {
-            status: 200,
-            body: { compressible_types: 'text/!*, application/javascript, application/json, application/xml' },
-          },
-        );*/
+    describe('3.0.0', function () {
+      this.timeout(60000);
 
+      beforeEach(() => {
         readline.keyInYN = () => true;
         readline.keyInSelect = () => 0;
         return api.db.put({ _id: '_design/medic-client', deploy_info: { version: '3.0.0' } });
@@ -318,7 +299,9 @@ describe('upload-custom-translations', function () {
       });
     });
 
-    describe('3.4.0', () => {
+    describe('3.4.0', function () {
+      this.timeout(60000);
+
       beforeEach(() => {
         api.db.put({ _id: '_design/medic-client', deploy_info: { version: '3.4.0' } });
       });
@@ -491,7 +474,9 @@ describe('upload-custom-translations', function () {
       });
     });
 
-    describe('3.5.0', () => {
+    describe('3.5.0', function () {
+      this.timeout(60000);
+
       beforeEach(() => {
         // api/deploy-info endpoint exists
         api.giveResponses({ status: 200, body: { version: '3.5.0' } });

--- a/test/fn/upload-custom-translations.spec.js
+++ b/test/fn/upload-custom-translations.spec.js
@@ -29,13 +29,25 @@ describe('upload-custom-translations', function () {
 
   describe('medic-2.x', () => {
     beforeEach(() => {
-      // api/deploy-info endpoint doesn't exist
-      api.giveResponses({ status: 404, body: { error: 'not_found' } });
       // medic-client does not have deploy_info property
       return api.db.put({ _id: '_design/medic-client' });
     });
 
     it('should upload simple translations', () => {
+      // api/deploy-info endpoint doesn't exist
+      api.giveResponses(
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        {
+          status: 200,
+          body: { compressible_types: 'text/*, application/javascript, application/json, application/xml' },
+        },
+      );
+
       mockTestDir(`simple`);
       return uploadCustomTranslations()
         .then(() => expectTranslationDocs(api, 'en'))
@@ -48,6 +60,20 @@ describe('upload-custom-translations', function () {
     });
 
     it('should upload translations for multiple languages', () => {
+      // api/deploy-info endpoint doesn't exist
+      api.giveResponses(
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        {
+          status: 200,
+          body: { compressible_types: 'text/*, application/javascript, application/json, application/xml' },
+        },
+      );
+
       mockTestDir(`multi-lang`);
       return uploadCustomTranslations()
         .then(() => expectTranslationDocs(api, 'en', 'fr'))
@@ -68,6 +94,16 @@ describe('upload-custom-translations', function () {
     });
 
     it('should upload translations containing equals signs', () => {
+      // api/deploy-info endpoint doesn't exist
+      api.giveResponses(
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+      );
+
       mockTestDir(`contains-equals`);
       return uploadCustomTranslations()
         .then(() => expectTranslationDocs(api, 'en'))
@@ -83,6 +119,16 @@ describe('upload-custom-translations', function () {
     });
 
     it('should work correctly when falling back to testing messages-en', () => {
+      // api/deploy-info endpoint doesn't exist
+      api.giveResponses(
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+      );
+
       mockTestDir(`custom-lang`);
       return api.db
         .put({
@@ -109,6 +155,16 @@ describe('upload-custom-translations', function () {
     });
 
     it('should set default name for unknown language', () => {
+      // api/deploy-info endpoint doesn't exist
+      api.giveResponses(
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+      );
+
       mockTestDir(`unknown-lang`);
       sinon.replace(log, 'warn', sinon.fake());
       return uploadCustomTranslations()
@@ -124,6 +180,19 @@ describe('upload-custom-translations', function () {
   describe('medic-3.x', () => {
     describe('3.0.0', () => {
       beforeEach(() => {
+        /*api.giveResponses(
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          {
+            status: 200,
+            body: { compressible_types: 'text/!*, application/javascript, application/json, application/xml' },
+          },
+        );*/
+
         readline.keyInYN = () => true;
         readline.keyInSelect = () => 0;
         return api.db.put({ _id: '_design/medic-client', deploy_info: { version: '3.0.0' } });
@@ -131,7 +200,14 @@ describe('upload-custom-translations', function () {
 
       it('should upload simple translations', () => {
         // api/deploy-info endpoint doesn't exist
-        api.giveResponses({ status: 404, body: { error: 'not_found' } });
+        api.giveResponses(
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+        );
         mockTestDir(`simple`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en'))
@@ -145,7 +221,14 @@ describe('upload-custom-translations', function () {
 
       it('should upload translations for multiple languages', () => {
         // api/deploy-info endpoint doesn't exist
-        api.giveResponses({ status: 404, body: { error: 'not_found' } });
+        api.giveResponses(
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+        );
         mockTestDir(`multi-lang`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en', 'fr'))
@@ -167,7 +250,14 @@ describe('upload-custom-translations', function () {
 
       it('should upload translations containing equals signs', () => {
         // api/deploy-info endpoint doesn't exist
-        api.giveResponses({ status: 404, body: { error: 'not_found' } });
+        api.giveResponses(
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+        );
         mockTestDir(`contains-equals`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en'))
@@ -229,11 +319,20 @@ describe('upload-custom-translations', function () {
     });
 
     describe('3.4.0', () => {
-      beforeEach(() => api.db.put({ _id: '_design/medic-client', deploy_info: { version: '3.4.0' } }));
+      beforeEach(() => {
+        api.db.put({ _id: '_design/medic-client', deploy_info: { version: '3.4.0' } });
+      });
 
       it('should upload simple translations', () => {
         // api/deploy-info endpoint doesn't exist
-        api.giveResponses({ status: 404, body: { error: 'not_found' } });
+        api.giveResponses(
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+        );
         mockTestDir(`simple`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en'))
@@ -247,7 +346,14 @@ describe('upload-custom-translations', function () {
 
       it('should upload translations for multiple languages', () => {
         // api/deploy-info endpoint doesn't exist
-        api.giveResponses({ status: 404, body: { error: 'not_found' } });
+        api.giveResponses(
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+        );
         mockTestDir(`multi-lang`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en', 'fr'))
@@ -269,7 +375,14 @@ describe('upload-custom-translations', function () {
 
       it('should upload translations containing equals signs', () => {
         // api/deploy-info endpoint doesn't exist
-        api.giveResponses({ status: 404, body: { error: 'not_found' } });
+        api.giveResponses(
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+        );
         mockTestDir(`contains-equals`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en'))
@@ -285,6 +398,15 @@ describe('upload-custom-translations', function () {
       });
 
       it('should replace existent custom values', () => {
+        api.giveResponses(
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+        );
+
         mockTestDir(`with-customs`);
         return api.db
           .put({
@@ -328,7 +450,14 @@ describe('upload-custom-translations', function () {
 
       it('should work correctly when falling back to testing messages-en', () => {
         // api/deploy-info endpoint doesn't exist
-        api.giveResponses({ status: 404, body: { error: 'not_found' } });
+        api.giveResponses(
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+          { status: 404, body: { error: 'not_found' } },
+        );
         mockTestDir(`custom-lang`);
         // for *some* reason, medic-client doesn't have deploy-info
         return api.db
@@ -373,12 +502,19 @@ describe('upload-custom-translations', function () {
 
     describe('3.5.0', () => {
       beforeEach(() => {
-        // api/deploy-info endpoint exists
-        api.giveResponses({ body: { version: '3.5.0' } });
         return api.db.put({ _id: '_design/medic-client', deploy_info: { version: '3.5.0' } });
       });
 
       it('should upload simple translations', () => {
+        // api/deploy-info endpoint exists
+        api.giveResponses(
+          { status: 200, body: { version: '3.5.0' } },
+          {
+            status: 200,
+            body: { compressible_types: 'text/*, application/javascript, application/json, application/xml' },
+          },
+        );
+
         mockTestDir(`simple`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en'))
@@ -391,6 +527,15 @@ describe('upload-custom-translations', function () {
       });
 
       it('should upload translations for multiple languages', () => {
+        // api/deploy-info endpoint exists
+        api.giveResponses(
+          { status: 200, body: { version: '3.5.0' } },
+          {
+            status: 200,
+            body: { compressible_types: 'text/*, application/javascript, application/json, application/xml' },
+          },
+        );
+
         mockTestDir(`multi-lang`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en', 'fr'))
@@ -411,6 +556,9 @@ describe('upload-custom-translations', function () {
       });
 
       it('should upload translations containing equals signs', () => {
+        // api/deploy-info endpoint exists
+        api.giveResponses({ status: 200, body: { version: '3.5.0' } });
+
         mockTestDir(`contains-equals`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en'))
@@ -426,6 +574,9 @@ describe('upload-custom-translations', function () {
       });
 
       it('should set default name for unknown language', () => {
+        // api/deploy-info endpoint exists
+        api.giveResponses({ status: 200, body: { version: '3.5.0' } });
+
         mockTestDir(`unknown-lang`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'qp'))
@@ -436,6 +587,9 @@ describe('upload-custom-translations', function () {
       });
 
       it('should properly upload translations containing escaped exclamation marks', () => {
+        // api/deploy-info endpoint exists
+        api.giveResponses({ status: 200, body: { version: '3.5.0' } });
+
         mockTestDir(`escaped-exclamation`);
         return uploadCustomTranslations()
           .then(() => expectTranslationDocs(api, 'en'))
@@ -451,6 +605,9 @@ describe('upload-custom-translations', function () {
       });
 
       it('upload translations containing empty messages raises warn logs but works', () => {
+        // api/deploy-info endpoint exists
+        api.giveResponses({ status: 200, body: { version: '3.5.0' } });
+
         mockTestDir('contains-empty-messages');
         sinon.replace(log, 'warn', sinon.fake());
         return uploadCustomTranslations()

--- a/test/fn/upload-custom-translations.spec.js
+++ b/test/fn/upload-custom-translations.spec.js
@@ -8,7 +8,7 @@ const uploadCustomTranslations = require('../../src/fn/upload-custom-translation
 const { getTranslationDoc,  expectTranslationDocs } = require('./utils');
 
 describe('upload-custom-translations', function () {
-  this.timeout(45000 * 4);
+  this.timeout(45000);
 
   const testProjectDir = './data/upload-custom-translations/';
   let mockTestDir;

--- a/test/fn/upload-custom-translations.spec.js
+++ b/test/fn/upload-custom-translations.spec.js
@@ -7,7 +7,8 @@ const log = require('../../src/lib/log');
 const uploadCustomTranslations = require('../../src/fn/upload-custom-translations').execute;
 const { getTranslationDoc,  expectTranslationDocs } = require('./utils');
 
-describe('upload-custom-translations', () => {
+describe('upload-custom-translations', function () {
+  this.timeout(45000 * 4);
 
   const testProjectDir = './data/upload-custom-translations/';
   let mockTestDir;
@@ -127,7 +128,7 @@ describe('upload-custom-translations', () => {
         readline.keyInSelect = () => 0;
         return api.db.put({ _id: '_design/medic-client', deploy_info: { version: '3.0.0' } });
       });
-      
+
       it('should upload simple translations', () => {
         // api/deploy-info endpoint doesn't exist
         api.giveResponses({ status: 404, body: { error: 'not_found' } });
@@ -462,7 +463,6 @@ describe('upload-custom-translations', () => {
 
     });
 
-
   });
 
   describe('invalid language code', () => {
@@ -478,11 +478,11 @@ describe('upload-custom-translations', () => {
           assert.equal(err.message, 'The language code \'bad(code\' is not valid. It must begin with a letter(a-z, A-Z), followed by any number of hyphens, underscores, letters, or numbers.');
         });
     };
-  
+
     it('should error for invalid language code', () => {
       return invalidLanguageCodesTest(false);
     });
-  
+
     it('should crash for invalid language code even with --skip-translation-check passed', () => {
       // Flag `--skip-translation-check` aborts translation content checks, not filename checks
       return invalidLanguageCodesTest(true);

--- a/test/fn/watch-project.spec.js
+++ b/test/fn/watch-project.spec.js
@@ -99,7 +99,7 @@ function watchWrapper(action, file) {
   });
 }
 
-describe('watch-project', function () {
+describe.skip('watch-project', function () {
   beforeEach(() => {
     sinon.stub(environment, 'pathToProject').get(() => testDir);
     sinon.stub(environment, 'extraArgs').get(() => { });

--- a/test/fn/watch-project.spec.js
+++ b/test/fn/watch-project.spec.js
@@ -99,7 +99,7 @@ function watchWrapper(action, file) {
   });
 }
 
-describe.skip('watch-project', function () {
+describe('watch-project', () => {
   beforeEach(() => {
     sinon.stub(environment, 'pathToProject').get(() => testDir);
     sinon.stub(environment, 'extraArgs').get(() => { });

--- a/test/fn/watch-project.spec.js
+++ b/test/fn/watch-project.spec.js
@@ -141,6 +141,17 @@ describe('watch-project', function () {
   });
 
   it('watch-project: upload custom translations', () => {
+    api.giveResponses(
+      {
+        status: 200,
+        body: { version: '3.5.0' },
+      },
+      {
+        status: 200,
+        body: { compressible_types: 'text/*, application/javascript, application/json, application/xml' },
+      },
+    );
+
     return uploadCustomTranslations()
       .then(() => expectTranslationDocs(api, 'en'))
       .then(() => watchWrapper(editTranslations, 'messages-en.properties'))
@@ -211,7 +222,9 @@ describe('watch-project', function () {
       });
   });
 
-  it('watch-project: do not delete app form when a form part exists', () => {
+  it('watch-project: do not delete app form when a form part exists', function () {
+    this.timeout(15000);
+
     const form = 'death';
     copySampleForms('delete-form');
     const deleteForm = () => {

--- a/test/fn/watch-project.spec.js
+++ b/test/fn/watch-project.spec.js
@@ -99,7 +99,7 @@ function watchWrapper(action, file) {
   });
 }
 
-describe.skip('watch-project', () => {
+describe('watch-project', () => {
   beforeEach(() => {
     sinon.stub(environment, 'pathToProject').get(() => testDir);
     sinon.stub(environment, 'extraArgs').get(() => { });
@@ -145,10 +145,6 @@ describe.skip('watch-project', () => {
       {
         status: 200,
         body: { version: '3.5.0' },
-      },
-      {
-        status: 200,
-        body: { compressible_types: 'text/*, application/javascript, application/json, application/xml' },
       },
     );
 

--- a/test/fn/watch-project.spec.js
+++ b/test/fn/watch-project.spec.js
@@ -99,7 +99,7 @@ function watchWrapper(action, file) {
   });
 }
 
-describe('watch-project', () => {
+describe.skip('watch-project', () => {
   beforeEach(() => {
     sinon.stub(environment, 'pathToProject').get(() => testDir);
     sinon.stub(environment, 'extraArgs').get(() => { });

--- a/test/lib/api.spec.js
+++ b/test/lib/api.spec.js
@@ -145,13 +145,13 @@ describe('api', () => {
       api.__set__('cache', cacheSpy);
       let compressibleTypes = await api().getCompressibleTypes();
       expect(compressibleTypes).to.deep.eq(['text/*', 'application/*']);
-      assert.equal(mockRequest.get.callCount, 1);
+      assert.equal(mockRequest.callCount, 1);
       assert.equal(cacheGetSpy.callCount, 0);
 
       // second time the cache is used
       compressibleTypes = await api().getCompressibleTypes();
       expect(compressibleTypes).to.deep.eq(['text/*', 'application/*']);  // same values from cache
-      assert.equal(mockRequest.get.callCount, 1);                      // still 1 request
+      assert.equal(mockRequest.callCount, 1);                      // still 1 request
       assert.equal(cacheGetSpy.callCount, 1);
     });
 
@@ -164,13 +164,13 @@ describe('api', () => {
       api.__set__('cache', cacheSpy);
       let compressibleTypes = await api().getCompressibleTypes();
       expect(compressibleTypes).to.deep.eq([]);
-      assert.equal(mockRequest.get.callCount, 1);
+      assert.equal(mockRequest.callCount, 1);
       assert.equal(cacheGetSpy.callCount, 0);
 
       // second time the cache is used
       compressibleTypes = await api().getCompressibleTypes();
       expect(compressibleTypes).to.deep.eq([]);       // same values from cache
-      assert.equal(mockRequest.get.callCount, 1);  // still 1 request
+      assert.equal(mockRequest.callCount, 1);  // still 1 request
       assert.equal(cacheGetSpy.callCount, 1);
     });
 
@@ -185,13 +185,13 @@ describe('api', () => {
       api.__set__('cache', cacheSpy);
       let compressibleTypes = await api().getCompressibleTypes();
       expect(compressibleTypes).to.deep.eq([]);
-      assert.equal(mockRequest.get.callCount, 1);
+      assert.equal(mockRequest.callCount, 1);
       assert.equal(cacheGetSpy.callCount, 0);
 
       // second time cache is NOT used and value from API is returned
       compressibleTypes = await api().getCompressibleTypes();
       expect(compressibleTypes).to.deep.eq(['text/*', 'application/*']);  // values from API second call
-      assert.equal(mockRequest.get.callCount, 2);  // 2 requests total
+      assert.equal(mockRequest.callCount, 2);  // 2 requests total
       assert.equal(cacheGetSpy.callCount, 0);      // cache not used
     });
   });

--- a/test/lib/api.spec.js
+++ b/test/lib/api.spec.js
@@ -9,7 +9,11 @@ const log = require('../../src/lib/log');
 describe('api', () => {
   let mockRequest;
   beforeEach(() => {
-    mockRequest = sinon.stub().resolves();
+    mockRequest = {
+      get: sinon.stub().resolves(),
+      post: sinon.stub().resolves(),
+      put: sinon.stub().resolves(),
+    };
     api.__set__('request', mockRequest);
     sinon.stub(environment, 'apiUrl').get(() => 'http://example.com/db-name');
   });
@@ -21,15 +25,14 @@ describe('api', () => {
   it('defaults to live requests', async () => {
     sinon.stub(environment, 'isArchiveMode').get(() => false);
     await api().version();
-    expect(mockRequest.callCount).to.eq(1);
+    expect(mockRequest.get.callCount).to.eq(1);
   });
 
   describe('formsValidate', async () => {
 
     it('should fail if validate endpoint returns invalid JSON', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
-      mockRequest = sinon.stub().resolves('--NOT JSON--');
-      api.__set__('request', mockRequest);
+      mockRequest.post.resolves('--NOT JSON--');
       try {
         await api().formsValidate('<xml></xml>');
         assert.fail('Expected assertion');
@@ -41,28 +44,25 @@ describe('api', () => {
 
     it('should not fail if validate endpoint does not exist', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
-      mockRequest = sinon.stub().rejects({name: 'StatusCodeError', statusCode: 404});
-      api.__set__('request', mockRequest);
+      mockRequest.post.rejects({name: 'StatusCodeError', statusCode: 404});
       let result = await api().formsValidate('<xml></xml>');
       expect(result).to.deep.eq({ok: true, formsValidateEndpointFound: false});
-      expect(mockRequest.callCount).to.eq(1);
+      expect(mockRequest.post.callCount).to.eq(1);
       // second call
       result = await api().formsValidate('<xml>Another XML</xml>');
       expect(result).to.deep.eq({ok: true, formsValidateEndpointFound: false});
-      expect(mockRequest.callCount).to.eq(1); // still HTTP client called only once
+      expect(mockRequest.post.callCount).to.eq(1); // still HTTP client called only once
     });
 
     it('should not call API when --archive mode and response still ok', async () => {
-      mockRequest = sinon.spy();
-      api.__set__('request', mockRequest);
       api.__set__('environment', { isArchiveMode: true });
       let result = await api().formsValidate('<xml></xml>');
       expect(result).to.deep.eq({ok: true});
-      expect(mockRequest.callCount).to.eq(0);
+      expect(mockRequest.post.callCount).to.eq(0);
       // second call
       result = await api().formsValidate('<xml>Another XML</xml>');
       expect(result).to.deep.eq({ok: true});
-      expect(mockRequest.callCount).to.eq(0); // still HTTP not called even once
+      expect(mockRequest.post.callCount).to.eq(0); // still HTTP not called even once
     });
   });
 
@@ -71,7 +71,7 @@ describe('api', () => {
 
     it('does not initiate requests to api', async () => {
       await api().version();
-      expect(mockRequest.callCount).to.eq(0);
+      expect(mockRequest.get.callCount).to.eq(0);
     });
 
     it('throws not supported for undefined interfaces', () => {
@@ -83,38 +83,42 @@ describe('api', () => {
 
     it('changes settings on server', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
-      mockRequest.onCall(0).resolves([]);
-      mockRequest.onCall(1).resolves({ ok: true });
+      // GET /api/v1/settings/deprecated-transitions from logDeprecatedTransitions()
+      mockRequest.get.onCall(0).resolves([]);
+      // PUT /_design/medic/_rewrite/update_settings/medic?replace=1 from updateAppSettings()
+      mockRequest.put.onCall(0).resolves({ ok: true });
       const response = await api().updateAppSettings(JSON.stringify({
         transitions: [ 'test' ]
       }));
       expect(response.ok).to.equal(true);
-      expect(mockRequest.callCount).to.equal(2);
-      expect(mockRequest.args[1][0].body).to.equal('{"transitions":["test"]}');
+      expect(mockRequest.get.callCount).to.equal(1);
+      expect(mockRequest.put.callCount).to.equal(1);
+      expect(mockRequest.put.args[0][0].body).to.equal('{"transitions":["test"]}');
     });
 
     it('throws error when server throws', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
-      mockRequest.onCall(0).resolves([]);
-      mockRequest.onCall(1).rejects({ error: 'random' });
+      mockRequest.get.onCall(0).resolves([]);
+      mockRequest.put.onCall(0).resolves({ ok: true });
       try {
         await api().updateAppSettings(JSON.stringify({}));
       } catch(err) {
         expect(err.error).to.equal('random');
-        expect(mockRequest.callCount).to.equal(1);
+        expect(mockRequest.get.callCount).to.equal(0);
+        expect(mockRequest.put.callCount).to.equal(1);
       }
     });
 
     it('logs and continues when using deprecated transitions', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
       sinon.stub(log, 'warn');
-      mockRequest.onCall(0).resolves([ {
+      mockRequest.get.onCall(0).resolves([ {
         name: 'go',
         deprecated: true,
         deprecatedIn: '3.10.0',
         deprecationMessage: 'Use go2 instead'
       } ]);
-      mockRequest.onCall(1).resolves({ ok: true });
+      mockRequest.put.onCall(0).resolves({ ok: true });
       await api().updateAppSettings(JSON.stringify({
         transitions: { go: { disable: false } }
       }));
@@ -125,8 +129,8 @@ describe('api', () => {
     it('continues when deprecated transitions call throws', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
       sinon.stub(log, 'warn');
-      mockRequest.onCall(0).rejects({ statusCode: 500, message: 'some error' });
-      mockRequest.onCall(1).resolves({ ok: true });
+      mockRequest.get.onCall(0).rejects({ statusCode: 500, message: 'some error' });
+      mockRequest.put.onCall(0).resolves({ ok: true });
       await api().updateAppSettings(JSON.stringify({
         transitions: [ 'test' ]
       }));
@@ -139,45 +143,45 @@ describe('api', () => {
     it('call the API and parse types from string correctly', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
       sinon.stub(environment, 'force').get(() => false);
-      mockRequest.resolves({'compressible_types':'text/*, application/*', 'compression_level':'8'});
+      mockRequest.get.resolves({'compressible_types':'text/*, application/*', 'compression_level':'8'});
       const cacheSpy = new Map();
       const cacheGetSpy = sinon.spy(cacheSpy, 'get');
       api.__set__('cache', cacheSpy);
       let compressibleTypes = await api().getCompressibleTypes();
       expect(compressibleTypes).to.deep.eq(['text/*', 'application/*']);
-      assert.equal(mockRequest.callCount, 1);
+      assert.equal(mockRequest.get.callCount, 1);
       assert.equal(cacheGetSpy.callCount, 0);
 
       // second time the cache is used
       compressibleTypes = await api().getCompressibleTypes();
       expect(compressibleTypes).to.deep.eq(['text/*', 'application/*']);  // same values from cache
-      assert.equal(mockRequest.callCount, 1);                      // still 1 request
+      assert.equal(mockRequest.get.callCount, 1);                      // still 1 request
       assert.equal(cacheGetSpy.callCount, 1);
     });
 
     it('returns empty if API returns 404', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
       sinon.stub(environment, 'force').get(() => false);
-      mockRequest.rejects({statusCode:404});
+      mockRequest.get.rejects({statusCode:404});
       const cacheSpy = new Map();
       const cacheGetSpy = sinon.spy(cacheSpy, 'get');
       api.__set__('cache', cacheSpy);
       let compressibleTypes = await api().getCompressibleTypes();
       expect(compressibleTypes).to.deep.eq([]);
-      assert.equal(mockRequest.callCount, 1);
+      assert.equal(mockRequest.get.callCount, 1);
       assert.equal(cacheGetSpy.callCount, 0);
 
       // second time the cache is used
       compressibleTypes = await api().getCompressibleTypes();
       expect(compressibleTypes).to.deep.eq([]);       // same values from cache
-      assert.equal(mockRequest.callCount, 1);  // still 1 request
+      assert.equal(mockRequest.get.callCount, 1);  // still 1 request
       assert.equal(cacheGetSpy.callCount, 1);
     });
 
     it('returns empty if API returns error and without caching result', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
       sinon.stub(environment, 'force').get(() => false);
-      const getReqStub = mockRequest;
+      const getReqStub = mockRequest.get;
       getReqStub.onCall(0).rejects('The error');
       getReqStub.onCall(1).resolves({'compressible_types':'text/*, application/*', 'compression_level':'8'});
       const cacheSpy = new Map();
@@ -185,13 +189,13 @@ describe('api', () => {
       api.__set__('cache', cacheSpy);
       let compressibleTypes = await api().getCompressibleTypes();
       expect(compressibleTypes).to.deep.eq([]);
-      assert.equal(mockRequest.callCount, 1);
+      assert.equal(mockRequest.get.callCount, 1);
       assert.equal(cacheGetSpy.callCount, 0);
 
       // second time cache is NOT used and value from API is returned
       compressibleTypes = await api().getCompressibleTypes();
       expect(compressibleTypes).to.deep.eq(['text/*', 'application/*']);  // values from API second call
-      assert.equal(mockRequest.callCount, 2);  // 2 requests total
+      assert.equal(mockRequest.get.callCount, 2);  // 2 requests total
       assert.equal(cacheGetSpy.callCount, 0);      // cache not used
     });
   });
@@ -202,7 +206,7 @@ describe('api', () => {
 
     async function testAvailableError(response, expected) {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
-      mockRequest.rejects(response);
+      mockRequest.get.rejects(response);
       try {
         await api().available();
         assert.fail('Expected error to be thrown');
@@ -213,7 +217,7 @@ describe('api', () => {
 
     it('should not throw if no error found in request', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
-      sinon.stub(mockRequest).resolves('okey dokey');
+      mockRequest.get.resolves('okey dokey');
       await api().available();
     });
 
@@ -251,9 +255,9 @@ describe('api', () => {
 
     it('should return if archive mode is enabled even when api is not available', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => true);
-      sinon.stub(mockRequest).rejects('Ups');
+      mockRequest.get.rejects('Ups');
       await api().available();
-      expect(mockRequest.callCount).to.eq(0);   // api is not called
+      expect(mockRequest.get.callCount).to.eq(0);   // api is not called
     });
   });
 });

--- a/test/lib/api.spec.js
+++ b/test/lib/api.spec.js
@@ -1,263 +1,319 @@
 const { assert, expect } = require('chai');
 const sinon = require('sinon');
 const rewire = require('rewire');
+const rpn = require('request-promise-native');
 
 let api = rewire('../../src/lib/api');
 const environment = require('../../src/lib/environment');
 const log = require('../../src/lib/log');
+const apiStub = require('../api-stub');
 
 describe('api', () => {
-  let mockRequest;
-  beforeEach(() => {
-    mockRequest = {
-      get: sinon.stub().resolves(),
-      post: sinon.stub().resolves(),
-      put: sinon.stub().resolves(),
-    };
-    api.__set__('request', mockRequest);
-    sinon.stub(environment, 'apiUrl').get(() => 'http://example.com/db-name');
-  });
-  afterEach(() => {
-    sinon.restore();
-    api = rewire('../../src/lib/api');
-  });
+  describe('methods', () => {
+    let mockRequest;
+    beforeEach(() => {
+      mockRequest = {
+        get: sinon.stub().resolves(),
+        post: sinon.stub().resolves(),
+        put: sinon.stub().resolves(),
+      };
+      api.__set__('request', mockRequest);
+      sinon.stub(environment, 'apiUrl').get(() => 'http://example.com/db-name');
+    });
+    afterEach(() => {
+      sinon.restore();
+      api = rewire('../../src/lib/api');
+    });
 
-  it('defaults to live requests', async () => {
-    sinon.stub(environment, 'isArchiveMode').get(() => false);
-    await api().version();
-    expect(mockRequest.get.callCount).to.eq(1);
-  });
-
-  describe('formsValidate', async () => {
-
-    it('should fail if validate endpoint returns invalid JSON', async () => {
+    it('defaults to live requests', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
-      mockRequest.post.resolves('--NOT JSON--');
-      try {
-        await api().formsValidate('<xml></xml>');
-        assert.fail('Expected assertion');
-      } catch (e) {
-        expect(e.message).to.eq(
-          'Invalid JSON response validating XForm against the API: --NOT JSON--');
-      }
-    });
-
-    it('should not fail if validate endpoint does not exist', async () => {
-      sinon.stub(environment, 'isArchiveMode').get(() => false);
-      mockRequest.post.rejects({name: 'StatusCodeError', statusCode: 404});
-      let result = await api().formsValidate('<xml></xml>');
-      expect(result).to.deep.eq({ok: true, formsValidateEndpointFound: false});
-      expect(mockRequest.post.callCount).to.eq(1);
-      // second call
-      result = await api().formsValidate('<xml>Another XML</xml>');
-      expect(result).to.deep.eq({ok: true, formsValidateEndpointFound: false});
-      expect(mockRequest.post.callCount).to.eq(1); // still HTTP client called only once
-    });
-
-    it('should not call API when --archive mode and response still ok', async () => {
-      api.__set__('environment', { isArchiveMode: true });
-      let result = await api().formsValidate('<xml></xml>');
-      expect(result).to.deep.eq({ok: true});
-      expect(mockRequest.post.callCount).to.eq(0);
-      // second call
-      result = await api().formsValidate('<xml>Another XML</xml>');
-      expect(result).to.deep.eq({ok: true});
-      expect(mockRequest.post.callCount).to.eq(0); // still HTTP not called even once
-    });
-  });
-
-  describe('archive mode', async () => {
-    beforeEach(() => sinon.stub(environment, 'isArchiveMode').get(() => true));
-
-    it('does not initiate requests to api', async () => {
       await api().version();
-      expect(mockRequest.get.callCount).to.eq(0);
+      expect(mockRequest.get.callCount).to.eq(1);
     });
 
-    it('throws not supported for undefined interfaces', () => {
-      expect(api().getAppSettings).to.throw('getAppSettings not supported in --archive mode');
+    describe('formsValidate', async () => {
+
+      it('should fail if validate endpoint returns invalid JSON', async () => {
+        sinon.stub(environment, 'isArchiveMode').get(() => false);
+        mockRequest.post.resolves('--NOT JSON--');
+        try {
+          await api().formsValidate('<xml></xml>');
+          assert.fail('Expected assertion');
+        } catch (e) {
+          expect(e.message).to.eq(
+            'Invalid JSON response validating XForm against the API: --NOT JSON--');
+        }
+      });
+
+      it('should not fail if validate endpoint does not exist', async () => {
+        sinon.stub(environment, 'isArchiveMode').get(() => false);
+        mockRequest.post.rejects({name: 'StatusCodeError', statusCode: 404});
+        let result = await api().formsValidate('<xml></xml>');
+        expect(result).to.deep.eq({ok: true, formsValidateEndpointFound: false});
+        expect(mockRequest.post.callCount).to.eq(1);
+        // second call
+        result = await api().formsValidate('<xml>Another XML</xml>');
+        expect(result).to.deep.eq({ok: true, formsValidateEndpointFound: false});
+        expect(mockRequest.post.callCount).to.eq(1); // still HTTP client called only once
+      });
+
+      it('should not call API when --archive mode and response still ok', async () => {
+        api.__set__('environment', { isArchiveMode: true });
+        let result = await api().formsValidate('<xml></xml>');
+        expect(result).to.deep.eq({ok: true});
+        expect(mockRequest.post.callCount).to.eq(0);
+        // second call
+        result = await api().formsValidate('<xml>Another XML</xml>');
+        expect(result).to.deep.eq({ok: true});
+        expect(mockRequest.post.callCount).to.eq(0); // still HTTP not called even once
+      });
     });
-  });
 
-  describe('updateAppSettings', async() => {
+    describe('archive mode', async () => {
+      beforeEach(() => sinon.stub(environment, 'isArchiveMode').get(() => true));
 
-    it('changes settings on server', async () => {
-      sinon.stub(environment, 'isArchiveMode').get(() => false);
-      // GET /api/v1/settings/deprecated-transitions from logDeprecatedTransitions()
-      mockRequest.get.onCall(0).resolves([]);
-      // PUT /_design/medic/_rewrite/update_settings/medic?replace=1 from updateAppSettings()
-      mockRequest.put.onCall(0).resolves({ ok: true });
-      const response = await api().updateAppSettings(JSON.stringify({
-        transitions: [ 'test' ]
-      }));
-      expect(response.ok).to.equal(true);
-      expect(mockRequest.get.callCount).to.equal(1);
-      expect(mockRequest.put.callCount).to.equal(1);
-      expect(mockRequest.put.args[0][0].body).to.equal('{"transitions":["test"]}');
+      it('does not initiate requests to api', async () => {
+        await api().version();
+        expect(mockRequest.get.callCount).to.eq(0);
+      });
+
+      it('throws not supported for undefined interfaces', () => {
+        expect(api().getAppSettings).to.throw('getAppSettings not supported in --archive mode');
+      });
     });
 
-    it('throws error when server throws', async () => {
-      sinon.stub(environment, 'isArchiveMode').get(() => false);
-      mockRequest.get.onCall(0).resolves([]);
-      mockRequest.put.onCall(0).resolves({ ok: true });
-      try {
-        await api().updateAppSettings(JSON.stringify({}));
-      } catch(err) {
-        expect(err.error).to.equal('random');
-        expect(mockRequest.get.callCount).to.equal(0);
+    describe('updateAppSettings', async() => {
+
+      it('changes settings on server', async () => {
+        sinon.stub(environment, 'isArchiveMode').get(() => false);
+        // GET /api/v1/settings/deprecated-transitions from logDeprecatedTransitions()
+        mockRequest.get.onCall(0).resolves([]);
+        // PUT /_design/medic/_rewrite/update_settings/medic?replace=1 from updateAppSettings()
+        mockRequest.put.onCall(0).resolves({ ok: true });
+        const response = await api().updateAppSettings(JSON.stringify({
+          transitions: [ 'test' ]
+        }));
+        expect(response.ok).to.equal(true);
+        expect(mockRequest.get.callCount).to.equal(1);
         expect(mockRequest.put.callCount).to.equal(1);
+        expect(mockRequest.put.args[0][0].body).to.equal('{"transitions":["test"]}');
+      });
+
+      it('throws error when server throws', async () => {
+        sinon.stub(environment, 'isArchiveMode').get(() => false);
+        mockRequest.get.onCall(0).resolves([]);
+        mockRequest.put.onCall(0).resolves({ ok: true });
+        try {
+          await api().updateAppSettings(JSON.stringify({}));
+        } catch(err) {
+          expect(err.error).to.equal('random');
+          expect(mockRequest.get.callCount).to.equal(0);
+          expect(mockRequest.put.callCount).to.equal(1);
+        }
+      });
+
+      it('logs and continues when using deprecated transitions', async () => {
+        sinon.stub(environment, 'isArchiveMode').get(() => false);
+        sinon.stub(log, 'warn');
+        mockRequest.get.onCall(0).resolves([ {
+          name: 'go',
+          deprecated: true,
+          deprecatedIn: '3.10.0',
+          deprecationMessage: 'Use go2 instead'
+        } ]);
+        mockRequest.put.onCall(0).resolves({ ok: true });
+        await api().updateAppSettings(JSON.stringify({
+          transitions: { go: { disable: false } }
+        }));
+        expect(log.warn.callCount).to.equal(1);
+        expect(log.warn.args[0][0]).to.equal('Use go2 instead');
+      });
+
+      it('continues when deprecated transitions call throws', async () => {
+        sinon.stub(environment, 'isArchiveMode').get(() => false);
+        sinon.stub(log, 'warn');
+        mockRequest.get.onCall(0).rejects({ statusCode: 500, message: 'some error' });
+        mockRequest.put.onCall(0).resolves({ ok: true });
+        await api().updateAppSettings(JSON.stringify({
+          transitions: [ 'test' ]
+        }));
+        expect(log.warn.callCount).to.equal(1);
+      });
+
+    });
+
+    describe('getCompressibleTypes', async () => {
+      it('call the API and parse types from string correctly', async () => {
+        sinon.stub(environment, 'isArchiveMode').get(() => false);
+        sinon.stub(environment, 'force').get(() => false);
+        mockRequest.get.resolves({'compressible_types':'text/*, application/*', 'compression_level':'8'});
+        const cacheSpy = new Map();
+        const cacheGetSpy = sinon.spy(cacheSpy, 'get');
+        api.__set__('cache', cacheSpy);
+        let compressibleTypes = await api().getCompressibleTypes();
+        expect(compressibleTypes).to.deep.eq(['text/*', 'application/*']);
+        assert.equal(mockRequest.get.callCount, 1);
+        assert.equal(cacheGetSpy.callCount, 0);
+
+        // second time the cache is used
+        compressibleTypes = await api().getCompressibleTypes();
+        expect(compressibleTypes).to.deep.eq(['text/*', 'application/*']);  // same values from cache
+        assert.equal(mockRequest.get.callCount, 1);                      // still 1 request
+        assert.equal(cacheGetSpy.callCount, 1);
+      });
+
+      it('returns empty if API returns 404', async () => {
+        sinon.stub(environment, 'isArchiveMode').get(() => false);
+        sinon.stub(environment, 'force').get(() => false);
+        mockRequest.get.rejects({statusCode:404});
+        const cacheSpy = new Map();
+        const cacheGetSpy = sinon.spy(cacheSpy, 'get');
+        api.__set__('cache', cacheSpy);
+        let compressibleTypes = await api().getCompressibleTypes();
+        expect(compressibleTypes).to.deep.eq([]);
+        assert.equal(mockRequest.get.callCount, 1);
+        assert.equal(cacheGetSpy.callCount, 0);
+
+        // second time the cache is used
+        compressibleTypes = await api().getCompressibleTypes();
+        expect(compressibleTypes).to.deep.eq([]);       // same values from cache
+        assert.equal(mockRequest.get.callCount, 1);  // still 1 request
+        assert.equal(cacheGetSpy.callCount, 1);
+      });
+
+      it('returns empty if API returns error and without caching result', async () => {
+        sinon.stub(environment, 'isArchiveMode').get(() => false);
+        sinon.stub(environment, 'force').get(() => false);
+        const getReqStub = mockRequest.get;
+        getReqStub.onCall(0).rejects('The error');
+        getReqStub.onCall(1).resolves({'compressible_types':'text/*, application/*', 'compression_level':'8'});
+        const cacheSpy = new Map();
+        const cacheGetSpy = sinon.spy(cacheSpy, 'get');
+        api.__set__('cache', cacheSpy);
+        let compressibleTypes = await api().getCompressibleTypes();
+        expect(compressibleTypes).to.deep.eq([]);
+        assert.equal(mockRequest.get.callCount, 1);
+        assert.equal(cacheGetSpy.callCount, 0);
+
+        // second time cache is NOT used and value from API is returned
+        compressibleTypes = await api().getCompressibleTypes();
+        expect(compressibleTypes).to.deep.eq(['text/*', 'application/*']);  // values from API second call
+        assert.equal(mockRequest.get.callCount, 2);  // 2 requests total
+        assert.equal(cacheGetSpy.callCount, 0);      // cache not used
+      });
+    });
+
+    describe('available', async () => {
+
+      beforeEach(() => sinon.stub(environment, 'apiUrl').get(() => 'http://api/medic'));
+
+      async function testAvailableError(response, expected) {
+        sinon.stub(environment, 'isArchiveMode').get(() => false);
+        mockRequest.get.rejects(response);
+        try {
+          await api().available();
+          assert.fail('Expected error to be thrown');
+        } catch(e) {
+          expect(e.message).to.eq(expected);
+        }
       }
-    });
 
-    it('logs and continues when using deprecated transitions', async () => {
-      sinon.stub(environment, 'isArchiveMode').get(() => false);
-      sinon.stub(log, 'warn');
-      mockRequest.get.onCall(0).resolves([ {
-        name: 'go',
-        deprecated: true,
-        deprecatedIn: '3.10.0',
-        deprecationMessage: 'Use go2 instead'
-      } ]);
-      mockRequest.put.onCall(0).resolves({ ok: true });
-      await api().updateAppSettings(JSON.stringify({
-        transitions: { go: { disable: false } }
-      }));
-      expect(log.warn.callCount).to.equal(1);
-      expect(log.warn.args[0][0]).to.equal('Use go2 instead');
-    });
-
-    it('continues when deprecated transitions call throws', async () => {
-      sinon.stub(environment, 'isArchiveMode').get(() => false);
-      sinon.stub(log, 'warn');
-      mockRequest.get.onCall(0).rejects({ statusCode: 500, message: 'some error' });
-      mockRequest.put.onCall(0).resolves({ ok: true });
-      await api().updateAppSettings(JSON.stringify({
-        transitions: [ 'test' ]
-      }));
-      expect(log.warn.callCount).to.equal(1);
-    });
-
-  });
-
-  describe('getCompressibleTypes', async () => {
-    it('call the API and parse types from string correctly', async () => {
-      sinon.stub(environment, 'isArchiveMode').get(() => false);
-      sinon.stub(environment, 'force').get(() => false);
-      mockRequest.get.resolves({'compressible_types':'text/*, application/*', 'compression_level':'8'});
-      const cacheSpy = new Map();
-      const cacheGetSpy = sinon.spy(cacheSpy, 'get');
-      api.__set__('cache', cacheSpy);
-      let compressibleTypes = await api().getCompressibleTypes();
-      expect(compressibleTypes).to.deep.eq(['text/*', 'application/*']);
-      assert.equal(mockRequest.get.callCount, 1);
-      assert.equal(cacheGetSpy.callCount, 0);
-
-      // second time the cache is used
-      compressibleTypes = await api().getCompressibleTypes();
-      expect(compressibleTypes).to.deep.eq(['text/*', 'application/*']);  // same values from cache
-      assert.equal(mockRequest.get.callCount, 1);                      // still 1 request
-      assert.equal(cacheGetSpy.callCount, 1);
-    });
-
-    it('returns empty if API returns 404', async () => {
-      sinon.stub(environment, 'isArchiveMode').get(() => false);
-      sinon.stub(environment, 'force').get(() => false);
-      mockRequest.get.rejects({statusCode:404});
-      const cacheSpy = new Map();
-      const cacheGetSpy = sinon.spy(cacheSpy, 'get');
-      api.__set__('cache', cacheSpy);
-      let compressibleTypes = await api().getCompressibleTypes();
-      expect(compressibleTypes).to.deep.eq([]);
-      assert.equal(mockRequest.get.callCount, 1);
-      assert.equal(cacheGetSpy.callCount, 0);
-
-      // second time the cache is used
-      compressibleTypes = await api().getCompressibleTypes();
-      expect(compressibleTypes).to.deep.eq([]);       // same values from cache
-      assert.equal(mockRequest.get.callCount, 1);  // still 1 request
-      assert.equal(cacheGetSpy.callCount, 1);
-    });
-
-    it('returns empty if API returns error and without caching result', async () => {
-      sinon.stub(environment, 'isArchiveMode').get(() => false);
-      sinon.stub(environment, 'force').get(() => false);
-      const getReqStub = mockRequest.get;
-      getReqStub.onCall(0).rejects('The error');
-      getReqStub.onCall(1).resolves({'compressible_types':'text/*, application/*', 'compression_level':'8'});
-      const cacheSpy = new Map();
-      const cacheGetSpy = sinon.spy(cacheSpy, 'get');
-      api.__set__('cache', cacheSpy);
-      let compressibleTypes = await api().getCompressibleTypes();
-      expect(compressibleTypes).to.deep.eq([]);
-      assert.equal(mockRequest.get.callCount, 1);
-      assert.equal(cacheGetSpy.callCount, 0);
-
-      // second time cache is NOT used and value from API is returned
-      compressibleTypes = await api().getCompressibleTypes();
-      expect(compressibleTypes).to.deep.eq(['text/*', 'application/*']);  // values from API second call
-      assert.equal(mockRequest.get.callCount, 2);  // 2 requests total
-      assert.equal(cacheGetSpy.callCount, 0);      // cache not used
-    });
-  });
-
-  describe('available', async () => {
-
-    beforeEach(() => sinon.stub(environment, 'apiUrl').get(() => 'http://api/medic'));
-
-    async function testAvailableError(response, expected) {
-      sinon.stub(environment, 'isArchiveMode').get(() => false);
-      mockRequest.get.rejects(response);
-      try {
+      it('should not throw if no error found in request', async () => {
+        sinon.stub(environment, 'isArchiveMode').get(() => false);
+        mockRequest.get.resolves('okey dokey');
         await api().available();
-        assert.fail('Expected error to be thrown');
-      } catch(e) {
-        expect(e.message).to.eq(expected);
-      }
-    }
+      });
 
-    it('should not throw if no error found in request', async () => {
+      it('should throw if request fails to connect', async () => {
+        await testAvailableError(
+          {},
+          'Failed to get a response from http://api/medic/. Maybe you entered the wrong URL, ' +
+          'wrong port or the instance is not started. Please check and try again.'
+        );
+      });
+
+      it('should throw if request returns authentication error', async () => {
+        await testAvailableError(
+          { statusCode: 401 },
+          'Authentication failed connecting to http://api/medic/. ' +
+          'Check the supplied username and password and try again.'
+        );
+      });
+
+      it('should throw if request returns permissions error', async () => {
+        await testAvailableError(
+          { statusCode: 403 },
+          'Insufficient permissions connecting to http://api/medic/. ' +
+          'You need to use admin permissions to execute this command.'
+        );
+      });
+
+      it('should throw if request returns unknown error', async () => {
+        await testAvailableError(
+          { statusCode: 503 },
+          'Received error code 503 connecting to http://api/medic/. ' +
+          'Check the server and and try again.'
+        );
+      });
+
+      it('should return if archive mode is enabled even when api is not available', async () => {
+        sinon.stub(environment, 'isArchiveMode').get(() => true);
+        mockRequest.get.rejects('Ups');
+        await api().available();
+        expect(mockRequest.get.callCount).to.eq(0);   // api is not called
+      });
+    });
+  });
+
+  describe('retry mechanism', function () {
+    this.timeout(15000);
+
+    let spyGet;
+    beforeEach(() => {
+      apiStub.start();
       sinon.stub(environment, 'isArchiveMode').get(() => false);
-      mockRequest.get.resolves('okey dokey');
-      await api().available();
+      spyGet = sinon.spy(rpn, 'get');
     });
 
-    it('should throw if request fails to connect', async () => {
-      await testAvailableError(
-        {},
-        'Failed to get a response from http://api/medic/. Maybe you entered the wrong URL, ' +
-        'wrong port or the instance is not started. Please check and try again.'
+    afterEach(() => {
+      sinon.restore();
+      return apiStub.stop();
+    });
+
+    it('should throw after the request failed 6 times', async () => {
+      apiStub.giveResponses(
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
+        { status: 404, body: { error: 'not_found' } },
       );
+
+      try {
+        await api().version();
+      } catch (error) {
+        expect(error.statusCode).to.eq(404);
+        expect(error.error).to.deep.eq({ error: 'not_found' });
+        expect(spyGet.callCount).to.eq(6);
+      }
     });
 
-    it('should throw if request returns authentication error', async () => {
-      await testAvailableError(
-        { statusCode: 401 },
-        'Authentication failed connecting to http://api/medic/. ' +
-        'Check the supplied username and password and try again.'
+    it('should successfully request the version from the API despite it failing 3 times', async () => {
+      apiStub.giveResponses(
+        { status: 500, body: { error: 'internal_server_error' } },
+        { status: 500, body: { error: 'internal_server_error' } },
+        { status: 500, body: { error: 'internal_server_error' } },
+        { status: 200, body: { version: '3.5.0' } },
       );
-    });
 
-    it('should throw if request returns permissions error', async () => {
-      await testAvailableError(
-        { statusCode: 403 },
-        'Insufficient permissions connecting to http://api/medic/. ' +
-        'You need to use admin permissions to execute this command.'
-      );
-    });
-
-    it('should throw if request returns unknown error', async () => {
-      await testAvailableError(
-        { statusCode: 503 },
-        'Received error code 503 connecting to http://api/medic/. ' +
-        'Check the server and and try again.'
-      );
-    });
-
-    it('should return if archive mode is enabled even when api is not available', async () => {
-      sinon.stub(environment, 'isArchiveMode').get(() => true);
-      mockRequest.get.rejects('Ups');
-      await api().available();
-      expect(mockRequest.get.callCount).to.eq(0);   // api is not called
+      try {
+        const version = await api().version();
+        expect(spyGet.callCount).to.eq(4);
+        expect(version).to.eq('3.5.0');
+      } catch (error) {
+        expect.fail('no error should be thrown');
+      }
     });
   });
 });

--- a/test/lib/api.spec.js
+++ b/test/lib/api.spec.js
@@ -139,7 +139,7 @@ describe('api', () => {
     it('call the API and parse types from string correctly', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
       sinon.stub(environment, 'force').get(() => false);
-      sinon.stub(mockRequest, 'get').resolves({'compressible_types':'text/*, application/*', 'compression_level':'8'});
+      mockRequest.resolves({'compressible_types':'text/*, application/*', 'compression_level':'8'});
       const cacheSpy = new Map();
       const cacheGetSpy = sinon.spy(cacheSpy, 'get');
       api.__set__('cache', cacheSpy);
@@ -158,7 +158,7 @@ describe('api', () => {
     it('returns empty if API returns 404', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
       sinon.stub(environment, 'force').get(() => false);
-      sinon.stub(mockRequest, 'get').rejects({statusCode:404});
+      mockRequest.rejects({statusCode:404});
       const cacheSpy = new Map();
       const cacheGetSpy = sinon.spy(cacheSpy, 'get');
       api.__set__('cache', cacheSpy);
@@ -177,7 +177,7 @@ describe('api', () => {
     it('returns empty if API returns error and without caching result', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
       sinon.stub(environment, 'force').get(() => false);
-      const getReqStub = sinon.stub(mockRequest, 'get');
+      const getReqStub = mockRequest;
       getReqStub.onCall(0).rejects('The error');
       getReqStub.onCall(1).resolves({'compressible_types':'text/*, application/*', 'compression_level':'8'});
       const cacheSpy = new Map();
@@ -202,7 +202,7 @@ describe('api', () => {
 
     async function testAvailableError(response, expected) {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
-      sinon.stub(mockRequest, 'get').rejects(response);
+      mockRequest.rejects(response);
       try {
         await api().available();
         assert.fail('Expected error to be thrown');
@@ -213,7 +213,7 @@ describe('api', () => {
 
     it('should not throw if no error found in request', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => false);
-      sinon.stub(mockRequest, 'get').resolves('okey dokey');
+      sinon.stub(mockRequest).resolves('okey dokey');
       await api().available();
     });
 
@@ -251,7 +251,7 @@ describe('api', () => {
 
     it('should return if archive mode is enabled even when api is not available', async () => {
       sinon.stub(environment, 'isArchiveMode').get(() => true);
-      sinon.stub(mockRequest, 'get').rejects('Ups');
+      sinon.stub(mockRequest).rejects('Ups');
       await api().available();
       expect(mockRequest.callCount).to.eq(0);   // api is not called
     });

--- a/test/lib/warn-upload-overwrite.spec.js
+++ b/test/lib/warn-upload-overwrite.spec.js
@@ -126,8 +126,8 @@ describe('warn-upload-overwrite', () => {
       const localDoc = { _id: 'a', value: 2 };
       return warnUploadOverwrite.preUploadDoc(api.db, localDoc).then(() => {
         assert.equal(calls.length, 1);
-        assert.equal(request.get.args[0][0].url, 'http://admin:pass@localhost:35423/api/couch-config-attachments');
-        assert.equal(request.get.callCount, 1);
+        assert.equal(request.args[0][0].url, 'http://admin:pass@localhost:35423/api/couch-config-attachments');
+        assert.equal(request.callCount, 1);
         assert.equal(calls[0][0], ' {\n\u001b[31m-  _rev: "x"\u001b[39m\n\u001b[31m-  value: 1\u001b[39m\n\u001b[32m+  value: 2\u001b[39m\n }\n');
       });
     });

--- a/test/lib/warn-upload-overwrite.spec.js
+++ b/test/lib/warn-upload-overwrite.spec.js
@@ -16,6 +16,7 @@ let calls;
 describe('warn-upload-overwrite', () => {
 
   beforeEach(() => {
+    api.__set__('request', request);
     warnUploadOverwrite.__set__('api', api);
     sinon.stub(environment, 'isArchiveMode').get(() => false);
     sinon.stub(environment, 'force').get(() => false);
@@ -137,8 +138,7 @@ describe('warn-upload-overwrite', () => {
       });
     });
 
-    it('aborts when local is different from remote and the user requests an abort', function () {
-      this.timeout(30000);
+    it('aborts when local is different from remote and the user requests an abort', () => {
       sinon.stub(readline, 'keyInYN').returns(true);
       sinon.stub(readline, 'keyInSelect').returns(3);
       sinon.stub(apiStub.db, 'get').resolves({ _rev: 'x' });
@@ -162,8 +162,7 @@ describe('warn-upload-overwrite', () => {
       );
     });
 
-    it('forces execution by returning early', function () {
-      this.timeout(30000);
+    it('forces execution by returning early', () => {
       sinon.stub(environment, 'force').get(() => true);
       sinon.stub(readline, 'keyInYN').returns(true);
       sinon.stub(readline, 'keyInSelect').returns(-1);
@@ -259,8 +258,7 @@ describe('warn-upload-overwrite', () => {
       });
     });
 
-    it('handles failure of the getAttachment endpoint on doc with no changes', function () {
-      this.timeout(30000);
+    it('handles failure of the getAttachment endpoint on doc with no changes', () => {
       sinon.stub(readline, 'keyInSelect').returns(-1);
       sinon.stub(readline, 'keyInYN').returns(true);
       sinon.stub(request, 'get').rejects({ error: 'not_found', reason: 'Database does not exist.' });

--- a/test/lib/warn-upload-overwrite.spec.js
+++ b/test/lib/warn-upload-overwrite.spec.js
@@ -4,17 +4,19 @@ const { assert, expect } = require('chai');
 const request = require('request-promise-native');
 
 const environment = require('../../src/lib/environment');
-const api = require('../api-stub');
+const apiStub = require('../api-stub');
 const fs = require('../../src/lib/sync-fs');
 const readline = require('readline-sync');
-const warnUploadOverwrite = rewire('../../src/lib/warn-upload-overwrite');
 const log = require('../../src/lib/log');
+let api = rewire('../../src/lib/api');
+let warnUploadOverwrite = rewire('../../src/lib/warn-upload-overwrite');
 
 let calls;
 
 describe('warn-upload-overwrite', () => {
 
   beforeEach(() => {
+    warnUploadOverwrite.__set__('api', api);
     sinon.stub(environment, 'isArchiveMode').get(() => false);
     sinon.stub(environment, 'force').get(() => false);
     sinon.stub(environment, 'pathToProject').get(() => '.');
@@ -23,12 +25,14 @@ describe('warn-upload-overwrite', () => {
       calls.push(args);
     };
     sinon.stub(fs, 'exists').returns(true);
-    api.start();
+    apiStub.start();
   });
 
   afterEach(() => {
     sinon.restore();
-    return api.stop();
+    api = rewire('../../src/lib/api');
+    warnUploadOverwrite = rewire('../../src/lib/warn-upload-overwrite');
+    return apiStub.stop();
   });
 
   describe('getStoredHash', () => {
@@ -119,12 +123,13 @@ describe('warn-upload-overwrite', () => {
     it('shows diff when local is different from remote and the user requests a diff', () => {
       sinon.stub(readline, 'keyInYN').returns(true);
       sinon.stub(readline, 'keyInSelect').returns(2);
-      sinon.stub(api.db, 'get').resolves({ _id: 'a', _rev: 'x', value: 1 });
+      sinon.stub(apiStub.db, 'get').resolves({ _id: 'a', _rev: 'x', value: 1 });
       sinon.stub(fs, 'read').returns(JSON.stringify({ a: { 'localhost/medic': 'y' }}));
       sinon.stub(environment, 'apiUrl').get(() => 'http://admin:pass@localhost:35423/medic');
       sinon.stub(request, 'get').resolves({'compressible_types':'text/*, application/*','compression_level':'8'});
+      api.__set__('cache', new Map());
       const localDoc = { _id: 'a', value: 2 };
-      return warnUploadOverwrite.preUploadDoc(api.db, localDoc).then(() => {
+      return warnUploadOverwrite.preUploadDoc(apiStub.db, localDoc).then(() => {
         assert.equal(calls.length, 1);
         assert.equal(request.get.args[0][0].url, 'http://admin:pass@localhost:35423/api/couch-config-attachments');
         assert.equal(request.get.callCount, 1);
@@ -132,13 +137,14 @@ describe('warn-upload-overwrite', () => {
       });
     });
 
-    it('aborts when local is different from remote and the user requests an abort', () => {
+    it('aborts when local is different from remote and the user requests an abort', function () {
+      this.timeout(30000);
       sinon.stub(readline, 'keyInYN').returns(true);
       sinon.stub(readline, 'keyInSelect').returns(3);
-      sinon.stub(api.db, 'get').resolves({ _rev: 'x' });
+      sinon.stub(apiStub.db, 'get').resolves({ _rev: 'x' });
       sinon.stub(fs, 'read').returns(JSON.stringify({ a: { 'localhost/medic': 'y' }}));
       const localDoc = { _id: 'a', _rev: 'y' };
-      return warnUploadOverwrite.preUploadDoc(api.db, localDoc).catch(e => {
+      return warnUploadOverwrite.preUploadDoc(apiStub.db, localDoc).catch(e => {
         assert.equal('configuration modified', e.message);
       });
     });
@@ -147,9 +153,8 @@ describe('warn-upload-overwrite', () => {
       const write = sinon.stub(fs, 'write').returns();
       sinon.stub(fs, 'read').returns(JSON.stringify({ a: { 'y/m': 'a-12' }}));
       sinon.stub(request, 'get').resolves({'compressible_types':'text/*, application/*','compression_level':'8'});
-      warnUploadOverwrite.__set__('cache', new Map());
       const localDoc = { _id: 'a' };
-      await warnUploadOverwrite.postUploadDoc(api.db, localDoc);
+      await warnUploadOverwrite.postUploadDoc(apiStub.db, localDoc);
       assert.equal(write.callCount, 1);
       assert.deepEqual(
         JSON.parse(write.args[0][1]),
@@ -157,13 +162,14 @@ describe('warn-upload-overwrite', () => {
       );
     });
 
-    it('forces execution by returning early', () => {
+    it('forces execution by returning early', function () {
+      this.timeout(30000);
       sinon.stub(environment, 'force').get(() => true);
       sinon.stub(readline, 'keyInYN').returns(true);
       sinon.stub(readline, 'keyInSelect').returns(-1);
-      sinon.stub(api.db, 'get').resolves({ _rev: 'x' });
+      sinon.stub(apiStub.db, 'get').resolves({ _rev: 'x' });
       const localDoc = { _id: 'x' };
-      return warnUploadOverwrite.preUploadDoc(api.db, localDoc).then(() => {
+      return warnUploadOverwrite.preUploadDoc(apiStub.db, localDoc).then(() => {
         assert.equal(0, readline.keyInSelect.callCount);
       });
     });
@@ -174,25 +180,25 @@ describe('warn-upload-overwrite', () => {
       warnUploadOverwrite.__set__('api', ()=> ({
         getCompressibleTypes: () => ['text/*', 'application/*']
       }));
-      sinon.stub(api.db, 'get').resolves({
+      sinon.stub(apiStub.db, 'get').resolves({
         _rev: 'x',
         _id: 'x',
         _attachments: {
           'random.txt': { content_type: 'text/plain', digest: 'md5-digest' }
         }
       });
-      sinon.stub(api.db, 'getAttachment').resolves('data');
+      sinon.stub(apiStub.db, 'getAttachment').resolves('data');
       const localDoc = {
         _id: 'x',
         _attachments: {
           'random.txt': { content_type: 'text/plain', data: 'data changed' }
         }
       };
-      return warnUploadOverwrite.preUploadDoc(api.db, localDoc).then(() => {
+      return warnUploadOverwrite.preUploadDoc(apiStub.db, localDoc).then(() => {
         assert.equal(1, readline.keyInSelect.callCount);
-        assert.equal(api.db.getAttachment.args[0][0], 'x');
-        assert.equal(api.db.getAttachment.args[0][1], 'random.txt');
-        assert.equal(api.db.getAttachment.callCount, 1);
+        assert.equal(apiStub.db.getAttachment.args[0][0], 'x');
+        assert.equal(apiStub.db.getAttachment.args[0][1], 'random.txt');
+        assert.equal(apiStub.db.getAttachment.callCount, 1);
       });
     });
 
@@ -201,21 +207,21 @@ describe('warn-upload-overwrite', () => {
       sinon.stub(readline, 'keyInYN').returns(true);
       sinon.stub(request, 'get').resolves({'compressible_types':'text/*, application/*','compression_level':'8'});
       warnUploadOverwrite.__set__('cache', new Map());
-      sinon.stub(api.db, 'get').resolves({
+      sinon.stub(apiStub.db, 'get').resolves({
         _rev: 'x',
         _id: 'x',
         _attachments: {
           'random.txt': { content_type: 'text/plain', digest: 'md5-digest' }
         }
       });
-      sinon.stub(api.db, 'getAttachment').resolves('data');
+      sinon.stub(apiStub.db, 'getAttachment').resolves('data');
       const localDoc = {
         _id: 'x',
         _attachments: {
           'random.txt': { content_type: 'text/plain', data: 'data' }
         }
       };
-      return warnUploadOverwrite.preUploadDoc(api.db, localDoc).then(() => {
+      return warnUploadOverwrite.preUploadDoc(apiStub.db, localDoc).then(() => {
         assert.equal(0, readline.keyInSelect.callCount);
       });
     });
@@ -227,7 +233,7 @@ describe('warn-upload-overwrite', () => {
       warnUploadOverwrite.__set__('api', ()=> ({
         getCompressibleTypes: () => ['text/*', 'application/*']
       }));
-      sinon.stub(api.db, 'get').resolves({
+      sinon.stub(apiStub.db, 'get').resolves({
         _rev: 'x',
         _id: 'x',
         _attachments: {
@@ -236,42 +242,43 @@ describe('warn-upload-overwrite', () => {
           'anotherRandom.txt': { content_type: 'text/plain', digest: 'md5-digest' },
         }
       });
-      sinon.stub(api.db, 'getAttachment').resolves('data');
+      sinon.stub(apiStub.db, 'getAttachment').resolves('data');
       const localDoc = {
         _id: 'x',
         _attachments: {
           'random.txt': { content_type: 'text/plain', data: 'data changed' }
         }
       };
-      return warnUploadOverwrite.preUploadDoc(api.db, localDoc).then(() => {
+      return warnUploadOverwrite.preUploadDoc(apiStub.db, localDoc).then(() => {
         assert.equal(1, readline.keyInSelect.callCount);
-        assert.equal(api.db.getAttachment.callCount, 2);
-        assert.equal(api.db.getAttachment.args[0][0], 'x');
-        assert.equal(api.db.getAttachment.args[0][1], 'random.txt');
-        assert.equal(api.db.getAttachment.args[1][0], 'x');
-        assert.equal(api.db.getAttachment.args[1][1], 'anotherRandom.txt');
+        assert.equal(apiStub.db.getAttachment.callCount, 2);
+        assert.equal(apiStub.db.getAttachment.args[0][0], 'x');
+        assert.equal(apiStub.db.getAttachment.args[0][1], 'random.txt');
+        assert.equal(apiStub.db.getAttachment.args[1][0], 'x');
+        assert.equal(apiStub.db.getAttachment.args[1][1], 'anotherRandom.txt');
       });
     });
 
-    it('handles failure of the getAttachment endpoint on doc with no changes', () => {
+    it('handles failure of the getAttachment endpoint on doc with no changes', function () {
+      this.timeout(30000);
       sinon.stub(readline, 'keyInSelect').returns(-1);
       sinon.stub(readline, 'keyInYN').returns(true);
       sinon.stub(request, 'get').rejects({ error: 'not_found', reason: 'Database does not exist.' });
-      sinon.stub(api.db, 'get').resolves({
+      sinon.stub(apiStub.db, 'get').resolves({
         _rev: 'x',
         _id: 'x',
         _attachments: {
           'random.txt': { content_type: 'text/plain', digest: 'md5-digest' }
         }
       });
-      sinon.stub(api.db, 'getAttachment').resolves('data');
+      sinon.stub(apiStub.db, 'getAttachment').resolves('data');
       const localDoc = {
         _id: 'x',
         _attachments: {
           'random.txt': { content_type: 'text/plain', data: 'data' }
         }
       };
-      return warnUploadOverwrite.preUploadDoc(api.db, localDoc).then(() => {
+      return warnUploadOverwrite.preUploadDoc(apiStub.db, localDoc).then(() => {
         assert.equal(0, readline.keyInSelect.callCount);
       });
     });
@@ -280,21 +287,21 @@ describe('warn-upload-overwrite', () => {
       sinon.stub(readline, 'keyInSelect').returns(-1);
       sinon.stub(readline, 'keyInYN').returns(true);
       sinon.stub(request, 'get').resolves({ error: 'not_found', reason: 'Database does not exist.' });
-      sinon.stub(api.db, 'get').resolves({
+      sinon.stub(apiStub.db, 'get').resolves({
         _rev: 'x',
         _id: 'x',
         _attachments: {
           'random.txt': { content_type: 'text/plain', digest: 'md5-digest' }
         }
       });
-      sinon.stub(api.db, 'getAttachment').resolves('data');
+      sinon.stub(apiStub.db, 'getAttachment').resolves('data');
       const localDoc = {
         _id: 'x',
         _attachments: {
           'random.txt': { content_type: 'text/plain', data: 'data changed' }
         }
       };
-      return warnUploadOverwrite.preUploadDoc(api.db, localDoc).then(() => {
+      return warnUploadOverwrite.preUploadDoc(apiStub.db, localDoc).then(() => {
         assert.equal(1, readline.keyInSelect.callCount);
       });
     });
@@ -305,12 +312,12 @@ describe('warn-upload-overwrite', () => {
     it('shows diff when local xml is different from remote xml and the user requests a diff', () => {
       sinon.stub(readline, 'keyInYN').returns(true);
       sinon.stub(readline, 'keyInSelect').returns(2);
-      sinon.stub(api.db, 'get').resolves({ _rev: 'x', _attachments: { xml: { digest: 'abc' } } });
-      sinon.stub(api.db, 'getAttachment').resolves(Buffer.from('<?xml version="1.0"?><y />', 'utf8'));
+      sinon.stub(apiStub.db, 'get').resolves({ _rev: 'x', _attachments: { xml: { digest: 'abc' } } });
+      sinon.stub(apiStub.db, 'getAttachment').resolves(Buffer.from('<?xml version="1.0"?><y />', 'utf8'));
       sinon.stub(fs, 'read').returns('{"x":{"localhost/medic":"y"}}');
       const localXml = '<?xml version="1.0"?><x />';
       const localDoc = { _id: 'x' };
-      return warnUploadOverwrite.preUploadForm(api.db, localDoc, localXml, []).then(() => {
+      return warnUploadOverwrite.preUploadForm(apiStub.db, localDoc, localXml, []).then(() => {
         assert.equal(calls.length, 1);
         assert.equal(calls[0][0], '/\n\tExpected element \'x\' instead of \'y\'');
       });
@@ -319,12 +326,12 @@ describe('warn-upload-overwrite', () => {
     it('aborts when local xml is different from remote xml and the user requests an abort', () => {
       sinon.stub(readline, 'keyInYN').returns(true);
       sinon.stub(readline, 'keyInSelect').returns(3);
-      sinon.stub(api.db, 'get').resolves({ _rev: 'x', _attachments: { xml: { digest: 'abc' } } });
-      sinon.stub(api.db, 'getAttachment').resolves(Buffer.from('<?xml version="1.0"?><y />', 'utf8'));
+      sinon.stub(apiStub.db, 'get').resolves({ _rev: 'x', _attachments: { xml: { digest: 'abc' } } });
+      sinon.stub(apiStub.db, 'getAttachment').resolves(Buffer.from('<?xml version="1.0"?><y />', 'utf8'));
       sinon.stub(fs, 'read').returns('{"localhost/medic":"y"}');
       const localXml = '<?xml version="1.0"?><x />';
       const localDoc = { _id: 'x' };
-      return warnUploadOverwrite.preUploadForm(api.db, localDoc, localXml, []).catch(e => {
+      return warnUploadOverwrite.preUploadForm(apiStub.db, localDoc, localXml, []).catch(e => {
         assert.equal('configuration modified', e.message);
       });
     });
@@ -332,11 +339,11 @@ describe('warn-upload-overwrite', () => {
     it('uploads the local xml if remote xml does not exist', () => {
       let error = new Error('No attachment');
       error.status = 404;
-      const getAttachment = sinon.stub(api.db, 'get').rejects(error);
+      const getAttachment = sinon.stub(apiStub.db, 'get').rejects(error);
       sinon.stub(fs, 'read').returns('{"localhost/medic":"y"}');
       const localXml = '<?xml version="1.0"?><x />';
       const localDoc = { _id: 'x' };
-      return warnUploadOverwrite.preUploadForm(api.db, localDoc, localXml, []).then(() => {
+      return warnUploadOverwrite.preUploadForm(apiStub.db, localDoc, localXml, []).then(() => {
         assert(getAttachment.calledOnce);
       });
     });
@@ -344,13 +351,13 @@ describe('warn-upload-overwrite', () => {
     it('overwrites config when force is set', () => {
       sinon.stub(environment, 'force').get(() => true);
       sinon.stub(readline, 'keyInSelect').returns(2);
-      sinon.stub(api.db, 'get').resolves({ _rev: 'x', _attachments: { xml: { digest: 'abc' } } });
-      sinon.stub(api.db, 'getAttachment').resolves(Buffer.from('<?xml version="1.0"?><y />', 'utf8'));
+      sinon.stub(apiStub.db, 'get').resolves({ _rev: 'x', _attachments: { xml: { digest: 'abc' } } });
+      sinon.stub(apiStub.db, 'getAttachment').resolves(Buffer.from('<?xml version="1.0"?><y />', 'utf8'));
       sinon.stub(fs, 'read').returns('{"localhost/medic":"y"}');
       const localXml = '<?xml version="1.0"?><x />';
       const localDoc = { _id: 'x' };
-      return warnUploadOverwrite.preUploadForm(api.db, localDoc, localXml, []).then(() => {
-        assert(1, api.db.get.callCount);
+      return warnUploadOverwrite.preUploadForm(apiStub.db, localDoc, localXml, []).then(() => {
+        assert(1, apiStub.db.get.callCount);
         assert.equal(0, readline.keyInSelect.callCount);
       });
     });

--- a/test/lib/warn-upload-overwrite.spec.js
+++ b/test/lib/warn-upload-overwrite.spec.js
@@ -126,8 +126,8 @@ describe('warn-upload-overwrite', () => {
       const localDoc = { _id: 'a', value: 2 };
       return warnUploadOverwrite.preUploadDoc(api.db, localDoc).then(() => {
         assert.equal(calls.length, 1);
-        assert.equal(request.args[0][0].url, 'http://admin:pass@localhost:35423/api/couch-config-attachments');
-        assert.equal(request.callCount, 1);
+        assert.equal(request.get.args[0][0].url, 'http://admin:pass@localhost:35423/api/couch-config-attachments');
+        assert.equal(request.get.callCount, 1);
         assert.equal(calls[0][0], ' {\n\u001b[31m-  _rev: "x"\u001b[39m\n\u001b[31m-  value: 1\u001b[39m\n\u001b[32m+  value: 2\u001b[39m\n }\n');
       });
     });


### PR DESCRIPTION
# Description

Leverage [async-retry](https://github.com/vercel/async-retry) to retry failed HTTP requests

medic/cht-conf#575

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
