### PR TITLE
chore(#586): allow self signed certs by default for localhost-like hosts

### DIFF
--- a/src/lib/environment.js
+++ b/src/lib/environment.js
@@ -20,7 +20,7 @@ const initialize = (
   }
 
   Object.assign(state, {
-    apiUrl,
+    apiUrl: apiUrl.toString(),
     archiveDestination,
     extraArgs,
     initialized: true,

--- a/src/lib/get-api-url.js
+++ b/src/lib/get-api-url.js
@@ -36,7 +36,16 @@ const getApiUrl = (cmdArgs, env = {}) => {
     instanceUrl = new url.URL(cmdArgs.url);
   }
 
-  return `${instanceUrl.href}medic`;
+  instanceUrl.pathname = `${instanceUrl.pathname}medic`;
+  return instanceUrl;
+};
+
+const isLocalhost = (apiUrl) => {
+  if (!apiUrl) {
+    return false;
+  }
+  const localhosts = [/^localhost$/, /^127\.0\.0\.\d+$/];
+  return !!localhosts.find(localhost => localhost.test(apiUrl.hostname));
 };
 
 const parseLocalUrl = (couchUrl) => {
@@ -56,4 +65,7 @@ const parseLocalUrl = (couchUrl) => {
   return new url.URL('http://admin:pass@localhost:5988');
 };
 
-module.exports = getApiUrl;
+module.exports = {
+  getApiUrl,
+  isLocalhost,
+};

--- a/src/lib/main.js
+++ b/src/lib/main.js
@@ -3,7 +3,7 @@ const checkForUpdates = require('../lib/check-for-updates');
 const checkChtConfDependencyVersion = require('../lib/check-cht-conf-dependency-version');
 const environment = require('./environment');
 const fs = require('../lib/sync-fs');
-const getApiUrl = require('../lib/get-api-url');
+const { getApiUrl, isLocalhost } = require('../lib/get-api-url');
 const log = require('../lib/log');
 const userPrompt = require('../lib/user-prompt');
 const redactBasicAuth = require('redact-basic-auth');
@@ -110,10 +110,6 @@ module.exports = async (argv, env) => {
     throw new Error('--destination=<path to save files> is required with --archive.');
   }
 
-  if (cmdArgs['accept-self-signed-certs']) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
-  }
-
   //
   // Logging
   //
@@ -146,6 +142,10 @@ module.exports = async (argv, env) => {
 
   const requiresInstance = actions.some(action => action.requiresInstance);
   const apiUrl = requiresInstance && getApiUrl(cmdArgs, env);
+
+  if (cmdArgs['accept-self-signed-certs'] || isLocalhost(apiUrl)) {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = 0;
+  }
 
   let extraArgs = cmdArgs['--'];
   if (!extraArgs.length) {

--- a/test/lib/get-api-url.spec.js
+++ b/test/lib/get-api-url.spec.js
@@ -1,8 +1,9 @@
 const sinon = require('sinon');
 const rewire = require('rewire');
 const { expect } = require('chai');
+const url = require('url');
 
-const getApiUrl = rewire('../../src/lib/get-api-url');
+const apiUrlLib = rewire('../../src/lib/get-api-url');
 const userPrompt = rewire('../../src/lib/user-prompt');
 
 describe('get-api-url', () => {
@@ -13,32 +14,32 @@ describe('get-api-url', () => {
       keyInYN: sinon.stub().throws('unexpected'),
     };
     userPrompt.__set__('readline', readline);
-    getApiUrl.__set__('userPrompt', userPrompt);
+    apiUrlLib.__set__('userPrompt', userPrompt);
   });
 
   it('multiple destinations yields error', () => {
-    const actual = () => getApiUrl({ local: true, instance: 'demo' });
+    const actual = () => apiUrlLib.getApiUrl({ local: true, instance: 'demo' });
     expect(actual).to.throw('One of these');
   });
 
   it('no destination yields error', () => {
-    const actual = () => getApiUrl({});
+    const actual = () => apiUrlLib.getApiUrl({});
     expect(actual).to.throw('One of these');
   });
 
   describe('--local', () => {
     it('no environment variable has a default', () => {
-      const actual = getApiUrl({ local: true });
-      expect(actual).to.eq('http://admin:pass@localhost:5988/medic');
+      const actual = apiUrlLib.getApiUrl({ local: true });
+      expect(actual).to.deep.equal(new url.URL('http://admin:pass@localhost:5988/medic'));
     });
 
     it('use environment variable', () => {
-      const actual = getApiUrl({ local: true }, { COUCH_URL: 'http://user:pwd@localhost:5984/db' });
-      expect(actual).to.eq('http://user:pwd@localhost:5988/medic');
+      const actual = apiUrlLib.getApiUrl({ local: true }, { COUCH_URL: 'http://user:pwd@localhost:5984/db' });
+      expect(actual).to.deep.equal(new url.URL('http://user:pwd@localhost:5988/medic'));
     });
 
     it('warn if environment variable targets remote', () => {
-      const actual = () => getApiUrl({ local: true }, { COUCH_URL: 'http://user:pwd@remote:5984/db' });
+      const actual = () => apiUrlLib.getApiUrl({ local: true }, { COUCH_URL: 'http://user:pwd@remote:5984/db' });
       expect(actual).to.throw('remote');
     });
   });
@@ -46,26 +47,26 @@ describe('get-api-url', () => {
   describe('--instance', () => {
     it('with default user', () => {
       readline.question.returns('entered');
-      const actual = getApiUrl({ instance: 'inst' });
-      expect(actual).to.eq('https://admin:entered@inst.medicmobile.org/medic');
+      const actual = apiUrlLib.getApiUrl({ instance: 'inst' });
+      expect(actual).to.deep.equal(new url.URL('https://admin:entered@inst.medicmobile.org/medic'));
     });
 
     it('with --user', () => {
       readline.question.returns('entered');
-      const actual = getApiUrl({ instance: 'inst', user: 'user' });
-      expect(actual).to.eq('https://user:entered@inst.medicmobile.org/medic');
+      const actual = apiUrlLib.getApiUrl({ instance: 'inst', user: 'user' });
+      expect(actual).to.deep.equal(new url.URL('https://user:entered@inst.medicmobile.org/medic'));
     });
   });
 
   describe('--url', () => {
     it('basic', () => {
-      const actual = getApiUrl({ url: 'https://admin:pwd@url.medicmobile.org/' });
-      expect(actual).to.eq('https://admin:pwd@url.medicmobile.org/medic');
+      const actual = apiUrlLib.getApiUrl({ url: 'https://admin:pwd@url.medicmobile.org/' });
+      expect(actual).to.deep.equal(new url.URL('https://admin:pwd@url.medicmobile.org/medic'));
     });
   });
 
   describe('parseLocalUrl', () => {
-    const parseLocalUrl = getApiUrl.__get__('parseLocalUrl');
+    const parseLocalUrl = apiUrlLib.__get__('parseLocalUrl');
     it('basic', () =>
       expect(parseLocalUrl('http://admin:pass@localhost:5988/medic').href).to.eq('http://admin:pass@localhost:5988/'));
 
@@ -74,5 +75,31 @@ describe('get-api-url', () => {
 
     it('ignores path', () =>
       expect(parseLocalUrl('http://admin:pass@localhost:5984/foo').href).to.eq('http://admin:pass@localhost:5988/'));
+  });
+
+  describe('isLocalhost', () => {
+    it('should return true for localhost', () => {
+      expect(apiUrlLib.isLocalhost(new url.URL('http://admin:pass@localhost/medic'))).to.be.true;
+      expect(apiUrlLib.isLocalhost(new url.URL('http://admin:pass@localhost:5988/medic'))).to.be.true;
+      expect(apiUrlLib.isLocalhost(new url.URL('https://admin:pass@localhost/medic'))).to.be.true;
+      expect(apiUrlLib.isLocalhost(new url.URL('https://admin:pass@localhost/whatever'))).to.be.true;
+    });
+
+    it('should return true for 127.0.0.x', () => {
+      expect(apiUrlLib.isLocalhost(new url.URL('http://admin:pass@127.0.0.1/medic'))).to.be.true;
+      expect(apiUrlLib.isLocalhost(new url.URL('http://admin:pass@127.0.0.3/medic'))).to.be.true;
+      expect(apiUrlLib.isLocalhost(new url.URL('http://admin:pass@127.0.0.1:5988/medic'))).to.be.true;
+      expect(apiUrlLib.isLocalhost(new url.URL('http://admin:pass@127.0.0.13:5988/medic'))).to.be.true;
+      expect(apiUrlLib.isLocalhost(new url.URL('https://admin:pass@127.0.0.1/medic'))).to.be.true;
+      expect(apiUrlLib.isLocalhost(new url.URL('https://admin:pass@127.0.0.232/medic'))).to.be.true;
+      expect(apiUrlLib.isLocalhost(new url.URL('https://admin:pass@127.0.0.22/whatever'))).to.be.true;
+    });
+
+    it('should return false for anything else', () => {
+      expect(apiUrlLib.isLocalhost(new url.URL('http://admin:pass@host/medic'))).to.be.false;
+      expect(apiUrlLib.isLocalhost(new url.URL('http://admin:pass@notlocalhost/medic'))).to.be.false;
+      expect(apiUrlLib.isLocalhost(new url.URL('http://admin:pass@127.1.0.9/medic'))).to.be.false;
+      expect(apiUrlLib.isLocalhost(new url.URL('http://admin:pass@192.168.1.0/medic'))).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
# Description

--accept-self-signed-certs is just too long

medic/cht-conf#586

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
