### PR TITLE
fix(#593): properly resolve the path to webpack loaders

### DIFF
--- a/src/lib/compilation/package-lib.js
+++ b/src/lib/compilation/package-lib.js
@@ -9,7 +9,7 @@ const { info, warn, error } = require('../log');
 
 module.exports = (pathToProject, entry, baseEslintPath, options = {}) => {
   const baseEslintConfig = fsUtils.readJson(baseEslintPath);
-  
+
   const directoryContainingEntry = path.dirname(entry);
   const libName = path.basename(directoryContainingEntry);
   info(`Packaging ${libName}`);
@@ -59,7 +59,7 @@ module.exports = (pathToProject, entry, baseEslintPath, options = {}) => {
         {
           enforce: 'pre',
           test: /\.js$/,
-          loader: 'eslint-loader',
+          loader: require.resolve('eslint-loader'),
           exclude: /node_modules/,
           options: {
             baseConfig: baseEslintConfig,
@@ -85,7 +85,7 @@ module.exports = (pathToProject, entry, baseEslintPath, options = {}) => {
         if (err.details) {
           error(err.details);
         }
-        
+
         return reject(err);
       }
 


### PR DESCRIPTION
# Description

use `require.resolve` to get the proper path to the webpack loader

medic/cht-conf#593

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
