### PR TITLE
perf(#600): drop support for Node versions < 18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,13 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 8.x, 10.x, 12.x, 14.x, 16.x, 18.x, 20.x ]
+        node-version: [ 18.x, 20.x ]
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: ${{ matrix.node-version }}
     - name: Install pyxform

--- a/.github/workflows/publish_docker_image.yml
+++ b/.github/workflows/publish_docker_image.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ CHT Conf is a command-line interface tool to manage and configure your apps buil
 
 # Requirements
 
-* nodejs 8 or later
-* python 2.7
+* nodejs 18 or later
+* python 3
 * or Docker
 
 # Installation
@@ -349,7 +349,7 @@ Builds brought to you courtesy of GitHub actions.
 
 # Copyright
 
-Copyright 2013-2023 Medic Mobile, Inc. <hello@medic.org>
+Copyright 2013-2024 Medic Mobile, Inc. <hello@medic.org>
 
 # License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "sinon": "^8.1.1"
       },
       "engines": {
-        "node": ">=8.10.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Configure CHT deployments",
   "main": "./src/lib/main.js",
   "engines": {
-    "node": ">=8.10.0"
+    "node": ">=18.0.0"
   },
   "scripts": {
     "clean": "rm -rf ./build/",


### PR DESCRIPTION
# Description

Dropping support for NodeJS < 18.

medic/cht-conf#600

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
