### PR TITLE
chore: update Dockerfile to be based on the Node 20 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-slim
+FROM node:20-slim
 
 RUN apt update \
     && apt install --no-install-recommends -y \
@@ -9,12 +9,17 @@ RUN apt update \
       openssh-client \
       python3-pip \
       python3-setuptools \
+      python3-venv \
       python3-wheel \
       xsltproc \
     # Remove chromium to save space. We only installed it to get the transitive dependencies that are needed
     # when running tests with puppeteer. (puppeteer-chromium-resolver will always download its own version of chromium)
     && apt remove -y chromium \
     && rm -rf /var/lib/apt/lists/*
+
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv "$VIRTUAL_ENV"
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN python3 -m pip install git+https://github.com/medic/pyxform.git@medic-conf-1.17#egg=pyxform-medic
 

--- a/test/e2e/.mocharc.js
+++ b/test/e2e/.mocharc.js
@@ -5,7 +5,7 @@ module.exports = {
   fullTrace: true,
   asyncOnly: false,
   spec: ['test/e2e/**/*.spec.js'],
-  timeout: 120_000, // spinning up a CHT instance takes a little long
+  timeout: 999_000, // spinning up a CHT instance takes a little long
   reporter: 'spec',
   file: ['test/e2e/hooks.js'],
   captureFile: 'test/e2e/results.txt',

--- a/test/e2e/.mocharc.js
+++ b/test/e2e/.mocharc.js
@@ -5,7 +5,7 @@ module.exports = {
   fullTrace: true,
   asyncOnly: false,
   spec: ['test/e2e/**/*.spec.js'],
-  timeout: 999_000, // spinning up a CHT instance takes a little long
+  timeout: 120_000, // spinning up a CHT instance takes a little long
   reporter: 'spec',
   file: ['test/e2e/hooks.js'],
   captureFile: 'test/e2e/results.txt',


### PR DESCRIPTION
# Description

Now that we are supporting Node 20, we can bump the version of Node used in the Dockerfile. The only impact this had is that the newer Python package is now requiring we install pyxform [into a virtual environment](https://medic.slack.com/archives/C024KTGRW/p1722392539299829).  

One solution would be to just run the `pip install` with the `--break-system-packages` flag which should be fine in a simple Docker image like this since the whole point of the containerization is that we don't have competing dependency stacks.  

That being said, after doing [some reading](https://pythonspeed.com/articles/activate-virtualenv-dockerfile/) I have instead opted for actually using a virtual environment here. It was not too much trouble and it felt more future-proof (and less janky).  

## Testing

We do not have any automated testing around the Dockerfile, but you can manually test its functionality with the following steps:

- Checkout this cht-conf branch locally and cd into the branch
- Build the docker image: `docker build -t medicmobile/cht-app-ide .`
- Follow the example from the docs to just run the docker image as a [standalone utility](https://docs.communityhealthtoolkit.org/contribute/code/cht-conf/#standalone-docker-utility).  
  - The most important action to validate is `compile-forms` since that is what will use the pyxform binaries.  

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
