### PR TITLE
fix(#635): update upload-artifact GH action to version 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
     - name: npm ci and test
       run: npm ci && npm test
     - name: Archive Results
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: Coverage Report ${{ matrix.node-version }}
         path: |

--- a/test/e2e/edit-app-settings.spec.js
+++ b/test/e2e/edit-app-settings.spec.js
@@ -12,6 +12,7 @@ const {
 
 describe('edit-app-settings', () => {
   const projectName = DEFAULT_PROJECT_NAME;
+  const findLanguage = (settingsLanguages, locale) => settingsLanguages.find(language => language.locale === locale);
 
   before(async () => {
     await initProject(projectName);
@@ -24,7 +25,8 @@ describe('edit-app-settings', () => {
   it('disables a language, recompile, and push app settings', async () => {
     const url = await getProjectUrl(projectName);
     const baseSettings = await request.get({ url: `${url}/api/v1/settings`, json: true });
-    baseSettings.languages.forEach(language => expect(language.enabled).to.be.true);
+    expect(findLanguage(baseSettings.languages, 'en').enabled).to.be.true;
+    expect(findLanguage(baseSettings.languages, 'fr').enabled).to.be.true;
     expect(baseSettings.locale).to.equal('en');
     expect(baseSettings.locale_outgoing).to.equal('en');
 


### PR DESCRIPTION
# Description

Update github-action `upload-artifact` to version 4. More details in the issue.

medic/cht-conf#635

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
