### PR TITLE
fix(#675): support duplicate_check prop

### DIFF
--- a/test/data/lib/upload-forms/duplicate_check-properties/forms/contact/example.properties.json
+++ b/test/data/lib/upload-forms/duplicate_check-properties/forms/contact/example.properties.json
@@ -1,0 +1,6 @@
+{
+  "duplicate_check": {
+    "expression": "levenshteinEq(current.name, existing.name, 3) && ageInYears(current) === ageInYears(existing)",
+    "disabled": true
+  }
+}

--- a/test/data/lib/upload-forms/duplicate_check-properties/forms/contact/example.xml
+++ b/test/data/lib/upload-forms/duplicate_check-properties/forms/contact/example.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<h:head>
+		<h:title>Merge properties</h:title>
+		<model>
+			<instance>
+				<data id="example" version="2015-06-05">
+					<name/>
+				</data>
+        <meta>
+          <instanceID/>
+        </meta>
+			</instance>
+			<bind nodeset="/data/name" type="string" />
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/name">
+			<label>What is the name?</label>
+		</input>
+	</h:body>
+</h:html>

--- a/test/data/lib/upload-forms/duplicate_check-properties/forms/report/example.properties.json
+++ b/test/data/lib/upload-forms/duplicate_check-properties/forms/report/example.properties.json
@@ -1,0 +1,5 @@
+{
+  "duplicate_check": {
+    "test": "This property is not supposed to be consumed for this form type"
+  }
+}

--- a/test/data/lib/upload-forms/duplicate_check-properties/forms/report/example.xml
+++ b/test/data/lib/upload-forms/duplicate_check-properties/forms/report/example.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:ev="http://www.w3.org/2001/xml-events" xmlns:h="http://www.w3.org/1999/xhtml" xmlns:jr="http://openrosa.org/javarosa" xmlns:orx="http://openrosa.org/xforms/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+	<h:head>
+		<h:title>Merge properties</h:title>
+		<model>
+			<instance>
+				<data id="example" version="2015-06-05">
+					<name/>
+				</data>
+        <meta>
+          <instanceID/>
+        </meta>
+			</instance>
+			<bind nodeset="/data/name" type="string" />
+		</model>
+	</h:head>
+	<h:body>
+		<input ref="/data/name">
+			<label>What is the name?</label>
+		</input>
+	</h:body>
+</h:html>


### PR DESCRIPTION
# Description

Add support for consuming and uploading the `duplicate_check` property when processing `contact` form `.properties` files.

Closes https://github.com/medic/cht-conf/issues/675

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
