### PR TITLE
fix: remove punycode deprecation via patch-package and npm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,24 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "overrides": {
+    "request": {
+      "tough-cookie": "2.5.0"
+    },
+    "request-promise-native": {
+      "tough-cookie": "2.5.0"
+    },
+    "fetch-cookie": {
+      "tough-cookie": "2.5.0"
+    }
+  },
   "scripts": {
     "clean": "rm -rf ./build/",
     "eslint": "eslint 'src/**/*.js' test/*.js 'test/**/*.js'",
     "test": "npm run clean && mkdir -p build/test && cp -r test/data build/test/data && cd build/test && nyc --reporter=html mocha \"../../test/**/*.spec.js\" --exclude \"../../test/e2e/**/*.spec.js\"",
     "test-e2e": "mocha --config test/e2e/.mocharc.js",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "postinstall": "patch-package"
   },
   "bin": {
     "medic-conf": "src/bin/index.js",
@@ -59,6 +71,7 @@
     "pouchdb-mapreduce": "^7.2.2",
     "pouchdb-session-authentication": "^1.4.0",
     "properties": "^1.2.1",
+    "punycode": "2.3.1",
     "queue-promise": "^2.2.1",
     "readline-sync": "^1.4.10",
     "redact-basic-auth": "^1.0.1",
@@ -90,6 +103,7 @@
     "husky": "^9.1.7",
     "mocha": "^11.1.0",
     "nyc": "^17.1.0",
+    "patch-package": "^8.0.0",
     "pouchdb-adapter-memory": "^7.2.2",
     "rewire": "^7.0.0",
     "semantic-release": "^22.0.0",

--- a/patches/pouchdb-replicator+4.2.0.patch
+++ b/patches/pouchdb-replicator+4.2.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/pouchdb-replicator/dist/pouchdb-replicator.js b/node_modules/pouchdb-replicator/dist/pouchdb-replicator.js
+index ad95708..9cc285e 100644
+--- a/node_modules/pouchdb-replicator/dist/pouchdb-replicator.js
++++ b/node_modules/pouchdb-replicator/dist/pouchdb-replicator.js
+@@ -4258,7 +4258,7 @@ module.exports = function() {
+ 
+ 'use strict';
+ 
+-var punycode = require('punycode');
++var punycode = require('punycode/');
+ var util = require('./util');
+ 
+ exports.parse = urlParse;

--- a/patches/psl+1.9.0.patch
+++ b/patches/psl+1.9.0.patch
@@ -1,0 +1,26 @@
+diff --git a/node_modules/psl/dist/psl.js b/node_modules/psl/dist/psl.js
+index 2e967df..f6766de 100644
+--- a/node_modules/psl/dist/psl.js
++++ b/node_modules/psl/dist/psl.js
+@@ -9380,7 +9380,7 @@ module.exports=[
+ 'use strict';
+ 
+ 
+-var Punycode = require('punycode');
++var Punycode = require('punycode/');
+ 
+ 
+ var internals = {};
+diff --git a/node_modules/psl/index.js b/node_modules/psl/index.js
+index da7bc12..f2dc899 100644
+--- a/node_modules/psl/index.js
++++ b/node_modules/psl/index.js
+@@ -2,7 +2,7 @@
+ 'use strict';
+ 
+ 
+-var Punycode = require('punycode');
++var Punycode = require('punycode/');
+ 
+ 
+ var internals = {};

--- a/patches/tough-cookie+2.5.0.patch
+++ b/patches/tough-cookie+2.5.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/tough-cookie/lib/cookie.js b/node_modules/tough-cookie/lib/cookie.js
+index 32dc0f8..526ea58 100644
+--- a/node_modules/tough-cookie/lib/cookie.js
++++ b/node_modules/tough-cookie/lib/cookie.js
+@@ -40,7 +40,7 @@ var VERSION = require('./version');
+ 
+ var punycode;
+ try {
+-  punycode = require('punycode');
++  punycode = require('punycode/');
+ } catch(e) {
+   console.warn("tough-cookie: can't load punycode; won't use punycode for domain normalization");
+ }


### PR DESCRIPTION
# Description

Fixes the Node.js deprecation warning [DEP0040] The 'punycode' module is deprecated by updating transitive dependencies to use the userland punycode/ alternative.

This patch ensures long-term compatibility with Node.js ≥ 21 and prevents CLI noise during usage of cht commands.

Changes include:

Added patch-package patches for:
- tough-cookie@2.5.0
- psl@1.9.0
- pouchdb-replicator@4.2.0

Used npm overrides to deduplicate and enforce the patched tough-cookie@2.5.0 version for:

- request
- request-promise-native
- fetch-cookie

Added a postinstall script to ensure patches are applied automatically after install

Fixes medic/cht-conf#655

## Proof of work
As we can see in this image no deprecation warning is coming
<img width="582" alt="image" src="https://github.com/user-attachments/assets/79ac8be9-a2ae-4bb1-b083-e89039f3d202" />


# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
