### PR TITLE
feat(#502): warn when using deprecated `db-object` appearance

### DIFF
--- a/src/lib/validation/form/deprecated-appearance.js
+++ b/src/lib/validation/form/deprecated-appearance.js
@@ -59,8 +59,7 @@ const createWarning = ({ ref, appearance, deprecatedAppearance }) => {
 const populateWarningHeader = (xformPath, warnings) => {
   if (warnings.length) {
     warnings.unshift(
-      `Form at ${xformPath} contains fields with a deprecated appearance. `
-      + 'Please update the following:'
+      `Form at ${xformPath} contains fields with a deprecated appearance. Please update the following:`
     );
   }
 };

--- a/src/lib/validation/form/deprecated-appearance.js
+++ b/src/lib/validation/form/deprecated-appearance.js
@@ -24,6 +24,11 @@ const getDeprecatedAppearances = (apiVersion) => [
     getReplacement: () => 'columns-pack no-buttons',
     versionDeprecated: '4.0.0'
   },
+  {
+    match: appearance => appearance.match(/(?:^|\s)db-object(?:$|\s)/),
+    getReplacement: () => 'select-contact',
+    versionDeprecated: '3.9.0'
+  },
 ].filter(deprecatedAppearance => semver.gte(apiVersion, deprecatedAppearance.versionDeprecated));
 
 const getElementsWithAppearance = (xmlDoc) => getNodes(xmlDoc, '/h:html/h:body//*[@appearance]');
@@ -54,8 +59,8 @@ const createWarning = ({ ref, appearance, deprecatedAppearance }) => {
 const populateWarningHeader = (xformPath, warnings) => {
   if (warnings.length) {
     warnings.unshift(
-      `Form at ${xformPath} contains fields with the deprecated \`horizontal\`/\`compact\` appearance. `
-      + 'These have been deprecated in favor of the `columns` appearance. Please update the following fields:'
+      `Form at ${xformPath} contains fields with a deprecated appearance. `
+      + 'Please update the following:'
     );
   }
 };

--- a/test/lib/validation/form/deprecated-appearance.spec.js
+++ b/test/lib/validation/form/deprecated-appearance.spec.js
@@ -21,7 +21,7 @@ const getXml = ({ name = '', age = '', address = '', streetNbr = '', city = '', 
           </address>
         </data>
       </instance>
-      <bind nodeset="/data/name" type="string" />   
+      <bind nodeset="/data/name" type="string" />
       <meta>
         <instanceID/>
       </meta>
@@ -60,8 +60,7 @@ const assertEmpty = (output) => {
 };
 
 const LATEST_VERSION = '999.99.99';
-const ERROR_HEADER = `Form at ${xformPath} contains fields with a deprecated appearance. ` +
-  'Please update the following:';
+const ERROR_HEADER = `Form at ${xformPath} contains fields with a deprecated appearance. Please update the following:`;
 
 describe('deprecated-appearance', () => {
   it(`resolves OK for form with no appearances`, () => {
@@ -180,7 +179,7 @@ describe('deprecated-appearance', () => {
     ['horizontal-compact', '4.0.0', 'columns-pack'],
     ['compact', '4.0.0', 'columns-pack no-buttons'],
     ['compact-1', '4.0.0', 'columns-1 no-buttons'],
-    ['db-object', '4.0.0', 'select-contact'],
+    ['db-object', '3.9.0', 'select-contact'],
   ].forEach(([appearance, apiVersion, replacement]) => {
     it(`returns error for deprecated [${appearance}] appearance when api version is [${apiVersion}]`, () => {
       const appearances = {


### PR DESCRIPTION
# Description

We add deprecation warnings when using the `db-object` appearance instead of the new `select-contact` appearance.
We also update the `ERROR_HEADER` to be more
generic.

Related discussion: https://forum.communityhealthtoolkit.org/t/warn-when-using-deprecated-db-object-appearance/4890/


Fixes #502.
# Code review items
- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
