### PR TITLE
feat(#683): add autocompletion feature for zsh 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ To enable tab completion in bash, add the following to your `.bashrc`/`.bash_pro
 
 	eval "$(cht --shell-completion=bash)"
 
+## Zsh completion
+To enable tab completion in zsh, add the following to your 
+`~/.zshrc` file:
+   
+    autoload -Uz compinit 
+    compinit
+    eval "$(cht --shell-completion=zsh)"
+	
 ## Upgrading
 
 To upgrade to the latest version

--- a/README.md
+++ b/README.md
@@ -69,11 +69,8 @@ To enable tab completion in bash, add the following to your `.bashrc`/`.bash_pro
 	eval "$(cht --shell-completion=bash)"
 
 ## Zsh completion
-To enable tab completion in zsh, add the following to your 
-`~/.zshrc` file:
+To enable tab completion in zsh, add the following to your `~/.zshrc` file:
    
-    autoload -Uz compinit 
-    compinit
     eval "$(cht --shell-completion=zsh)"
 	
 ## Upgrading

--- a/src/cli/shell-completion-setup.js
+++ b/src/cli/shell-completion-setup.js
@@ -1,6 +1,6 @@
 const fs = require('../lib/sync-fs');
 
-const SUPPORTED_SHELLS = ['bash'];
+const SUPPORTED_SHELLS = ['bash','zsh'];
 
 module.exports = shell => {
   if (SUPPORTED_SHELLS.includes(shell)){

--- a/src/cli/shell-completion.zsh
+++ b/src/cli/shell-completion.zsh
@@ -1,0 +1,24 @@
+#compdef cht
+
+_cht() {
+    local curcontext="$curcontext" state line
+    typeset -A opt_args
+    
+    # Get the current word being completed
+    local current_word="${words[CURRENT]}"
+    local current_pos=$CURRENT
+    
+    # Call the shell-completion-for-cht program with appropriate arguments
+    local completion_options
+    completion_options=$(shell-completion-for-cht $((current_pos-1)) "$current_word")
+    
+    # Convert the output into an array
+    local -a completion_array
+    completion_array=(${(f)completion_options})
+    
+    # Provide the completions
+    _describe 'commands' completion_array
+}
+
+# Register the completion function
+compdef _cht cht

--- a/src/cli/shell-completion.zsh
+++ b/src/cli/shell-completion.zsh
@@ -9,6 +9,9 @@ _cht() {
     local current_pos=$CURRENT
     
     # Call the shell-completion-for-cht program to get available options
+    # current_pos - 1 gives the index of the previous word, which is typically the argument it is the word just before the current word
+    # previous_word helps in setting correct context for the completion
+    
     local completion_options
     completion_options=$(shell-completion-for-cht $((current_pos-1)) "$current_word")
     

--- a/src/cli/shell-completion.zsh
+++ b/src/cli/shell-completion.zsh
@@ -8,17 +8,16 @@ _cht() {
     local current_word="${words[CURRENT]}"
     local current_pos=$CURRENT
     
-    # Call the shell-completion-for-cht program with appropriate arguments
+    # Call the shell-completion-for-cht program to get available options
     local completion_options
     completion_options=$(shell-completion-for-cht $((current_pos-1)) "$current_word")
     
-    # Convert the output into an array
+    # Split the output by spaces into an array
     local -a completion_array
-    completion_array=(${(f)completion_options})
+    completion_array=(${=completion_options})
     
-    # Provide the completions
-    _describe 'commands' completion_array
+    # Provide completions
+    compadd -a completion_array
 }
-
-# Register the completion function
-compdef _cht cht
+    #Register the completion function
+    compdef _cht cht


### PR DESCRIPTION
# Description

added autocompletion feature similar to bash for zsh

closes #683 

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
