### PR TITLE
feat(#712)!: update targeted NodeJS versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ 18.x, 20.x, 22.x ]
+        node-version: [ 20.x, 22.x, 24.x ]
       fail-fast: false
 
     steps:
@@ -42,7 +42,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 18.x
+        node-version: 24.x
     - name: Install dependencies
       run: |
         pip install git+https://github.com/medic/pyxform.git@medic-conf-1.17#egg=pyxform-medic

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
       - name: Install dependencies
         run: npm ci
       - name: Release

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Configure CHT deployments",
   "main": "./src/lib/main.js",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "clean": "rm -rf ./build/",


### PR DESCRIPTION
# Description

Closes #712 

https://endoflife.date/nodejs

Add NodeJS 24 as a target.

BREAKING CHANGE: remove support for NodeJS 18

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
