### PR TITLE
chore(na): Add warning  to usage output

### DIFF
--- a/src/cli/usage.js
+++ b/src/cli/usage.js
@@ -8,8 +8,13 @@ ${bold('NAME')}
 
 ${bold('SYNOPSIS')}
   cht <--local|--instance=instance-name|--url=url>
+  
 Or:
+
   cht <--local|--instance=instance-name|--url=url|--archive> <actions> <options> -- <params>
+
+${underscore('Note')}: If no <actions>,<options> or <params> are NOT passed but --local or --instance or --url IS passed, 
+   all supported actions are called.
 
 ${bold('DESCRIPTION')}
   This script updates and uploads a project's configuration.
@@ -74,3 +79,4 @@ ${bold('OPTIONS')}
 };
 
 const bold = text => `\x1b[1m${text}\x1b[0m`;
+const underscore = text => `\x1b[4m${text}\x1b[0m`


### PR DESCRIPTION
# Description

Add warning  to usage output

See related [forum post](https://forum.communityhealthtoolkit.org/t/clarification-on-cht-url-https-username-password-172-20-252-111-local-ip-medicmobile-org-10443-command-and-its-impact/5257)

medic/cht-conf#[number]

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
