### PR TITLE
feat(#753): add deprecated tel type validation

### DIFF
--- a/src/lib/validation/form/deprecated-tel-type.js
+++ b/src/lib/validation/form/deprecated-tel-type.js
@@ -1,0 +1,36 @@
+const semver = require('semver');
+const { getBindNodes } = require('../../forms-utils');
+
+const validateDeprecatedTelType = async({xformPath, xmlDoc, apiVersion}) => {
+  if(!apiVersion)
+  {
+    return {errors:[], warnings:[]};
+  }
+
+  if(semver.lt(apiVersion, '4.11.0'))
+  {
+    return {errors:[], warnings:[]};
+  }
+
+  const warnings = [];
+
+  const telNodesets = getBindNodes(xmlDoc)
+    .filter(bind => bind.getAttribute('type') === 'tel')
+    .map(bind => bind.getAttribute('nodeset'))
+    .filter(Boolean);
+    
+  if(telNodesets.length)
+  {
+    warnings.push(
+      `Form at ${xformPath} contains the following phone number fields with the deprecated 'tel' type [${telNodesets.join(', ')}]. Follow the documentation to update these fields to the supported type:\nhttps://docs.communityhealthtoolkit.org/building/forms/app/#phone-number-input`
+    );
+  }
+
+  return {errors:[], warnings};
+};
+
+module.exports = {
+  requiresInstance: true,
+  skipFurtherValidation: false,
+  execute: validateDeprecatedTelType
+};

--- a/test/lib/validate-forms.spec.js
+++ b/test/lib/validate-forms.spec.js
@@ -67,6 +67,11 @@ describe('validate-forms', () => {
     expect(deprecatedAppearance.requiresInstance).to.equal(true);
     expect(deprecatedAppearance.skipFurtherValidation).to.equal(false);
 
+    const deprecatedTelType = validations.shift();
+    expect(deprecatedTelType.name).to.equal('deprecated-tel-type.js');
+    expect(deprecatedTelType.requiresInstance).to.equal(true);
+    expect(deprecatedTelType.skipFurtherValidation).to.equal(false);
+
     const noRequiredNotes = validations.shift();
     expect(noRequiredNotes.name).to.equal('no-required-notes.js');
     expect(noRequiredNotes.requiresInstance).to.equal(false);

--- a/test/lib/validation/form/deprecated-tel-type.spec.js
+++ b/test/lib/validation/form/deprecated-tel-type.spec.js
@@ -1,0 +1,105 @@
+const { expect } = require('chai');
+const { DOMParser } = require('@xmldom/xmldom');
+const deprecatedTelType = require('../../../../src/lib/validation/form/deprecated-tel-type');
+
+const domParser = new DOMParser();
+
+// Simple XML helper - only focuses on what we need to test: bind elements with type attributes
+const getXml = ({ phoneType = 'string', altPhoneType = 'string', nameType = 'string' }) => `
+<?xml version="1.0"?>
+<h:html xmlns="http://www.w3.org/2002/xforms" xmlns:h="http://www.w3.org/1999/xhtml">
+  <h:head>
+    <h:title>Test Form</h:title>
+    <model>
+      <instance>
+        <data>
+          <phone/>
+          <phone_alternate/>
+          <name/>
+        </data>
+      </instance>
+      <bind nodeset="/data/phone" type="${phoneType}" />
+      <bind nodeset="/data/phone_alternate" type="${altPhoneType}" />
+      <bind nodeset="/data/name" type="${nameType}" />
+    </model>
+  </h:head>
+  <h:body>
+    <input ref="/data/phone">
+      <label>Phone</label>
+    </input>
+    <input ref="/data/phone_alternate">
+      <label>Alt Phone</label>
+    </input>
+    <input ref="/data/name">
+      <label>Name</label>
+    </input>
+  </h:body>
+</h:html>`;
+
+const LATEST_VERSION = '999.99.99';
+
+const getXmlDoc = (types = {}) => domParser.parseFromString(getXml(types));
+const xformPath = '/my/form/path/form.xml';
+
+const assertEmpty = (output) => {
+  expect(output.warnings).is.empty;
+  expect(output.errors, output.errors).is.empty;
+};
+
+describe('deprecated-tel-type', () => {
+  it('resolves OK when no tel fields', () => {
+    return deprecatedTelType
+      .execute({xformPath, xmlDoc: getXmlDoc(), apiVersion: LATEST_VERSION})
+      .then(output => assertEmpty(output));
+  });
+
+  it('resolves OK when no API version', () =>{
+    const types = {
+      phoneType: 'tel',
+      altPhoneType: 'tel',
+      nameType: 'string'
+    };
+    return deprecatedTelType
+      .execute({xformPath, xmlDoc: getXmlDoc(types)})
+      .then(output => assertEmpty(output));
+  });
+
+  it('resolves OK when API version < 4.11.0', () =>{
+    const types = {
+      phoneType: 'tel',
+      altPhoneType: 'tel',
+      nameType: 'string'
+    };
+    return deprecatedTelType
+      .execute({xformPath, xmlDoc: getXmlDoc(types), apiVersion: '4.10.9'})
+      .then(output => assertEmpty(output));
+  });
+
+  it('returns warning for tel fields', () =>{
+    const types = {
+      phoneType: 'tel',
+      altPhoneType: 'tel',
+      nameType: 'string'
+    };
+    return deprecatedTelType
+      .execute({xformPath, xmlDoc: getXmlDoc(types), apiVersion: LATEST_VERSION})
+      .then(output => {
+        expect(output.warnings[0]).to.equal(`Form at /my/form/path/form.xml contains the following phone number fields with the deprecated 'tel' type [/data/phone, /data/phone_alternate]. Follow the documentation to update these fields to the supported type:\nhttps://docs.communityhealthtoolkit.org/building/forms/app/#phone-number-input`);
+      });
+  });
+
+  it('ignores non-tel fields', () =>{
+    const types = {
+      phoneType: 'tel',
+      altPhoneType: 'string',
+      nameType: 'string'
+    };
+    return deprecatedTelType
+      .execute({xformPath, xmlDoc: getXmlDoc(types), apiVersion: LATEST_VERSION})
+      .then(output => {
+        expect(output.warnings[0]).to.equal(`Form at /my/form/path/form.xml contains the following phone number fields with the deprecated 'tel' type [/data/phone]. Follow the documentation to update these fields to the supported type:\nhttps://docs.communityhealthtoolkit.org/building/forms/app/#phone-number-input`);
+      });
+  });
+});
+
+


### PR DESCRIPTION
Warn when forms use deprecated 'tel' type for API versions >= 4.11.0

# Description

- Validates bind elements with type="tel" 
- Only applies to API versions 4.11.0+
- Includes unit tests covering all scenarios

medic/cht-conf#[753]
Closes #753

# Code review items

- Readable: Concise, well named, follows the [style guide](https://docs.communityhealthtoolkit.org/contribute/code/style-guide/), documented if necessary.
- Documented: Configuration and user documentation on [cht-docs](https://github.com/medic/cht-docs/)
- Tested: Unit and/or integration tests where appropriate
- Backwards compatible: Works with existing data and configuration. Any breaking changes documented in the release notes.

# License

The software is provided under AGPL-3.0. Contributions to this project are accepted under the same license.
